### PR TITLE
Afregistrer koordinater med DB trigger fremfor API-kode

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -335,7 +335,6 @@ class FireDb(object):
                 raise Exception(
                     f"Added beregning cannot refer to existing koordinat: {koordinat}"
                 )
-            self._close_existing_koordinat(koordinat)
             koordinat.sagsevent = sagsevent
         self.session.add(beregning)
         self.session.commit()
@@ -411,45 +410,5 @@ class FireDb(object):
         # state.deleted     # session & identity_key, flushed but not committed. Commit moves it to detached state
         insp = inspect(obj)
         return not (insp.persistent or insp.detached)
-
-    def _close_existing_koordinat(self, newkoordinat):
-        """Checks if a previous version of the new koordinat exists. If it exists the existing koordinat is closed.
-
-        Parameters
-        ----------
-        newkoordinat: koordinat
-            New koordinat object to insert into database. The koordinat must have its punkt-reference set before calling
-            this method.
-        """
-        if not self._is_new_object(newkoordinat):
-            return
-
-        if not newkoordinat.punkt:
-            raise Exception("koordinat must have a reference to its punkt")
-
-        # Find existing koordinat with the same properties
-        # According to constraint "KOOR_UNIQ_001" koordinates must be unique with regard to
-        # SRID, PUNKTID, REGISTRERINGTIL
-        # Note that new koordinat MAY have int srid
-        # Note that we have noth srid and sridtype and we need to check both...
-        existing_koordinater = list(
-            [
-                k
-                for k in newkoordinat.punkt.koordinater
-                if str(k.srid.name) == str(newkoordinat.srid.name)
-                and k.registreringtil is None
-                and k is not newkoordinat
-            ]
-        )
-        assert (
-            len(existing_koordinater) <= 1
-        ), f"Punkt has more than one koordinat with srid={newkoordinat.srid} and registeringtil=None"
-
-        if existing_koordinater:
-            # self.session.expunge(newkoordinat)
-            # Close the existing version (if any)
-            for k in existing_koordinater:
-                k._registreringtil = func.sysdate()
-            # self.session.add(newkoordinat)
 
     # endregion

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -147,7 +147,7 @@ class Koordinat(FikspunktregisterObjekt):
     sy = Column(Float)
     sz = Column(Float)
     t = Column(DateTime(timezone=True))
-    transformeret = Column(String, nullable=False)
+    transformeret = Column(String, nullable=False, default="false")
     artskode = Column(IntEnum(Artskode), default=Artskode.NETVAERK_AF_LAV_KVALITET)
     x = Column(Float)
     y = Column(Float)

--- a/test/test_koordinat.py
+++ b/test/test_koordinat.py
@@ -1,5 +1,16 @@
+import uuid
+import datetime as dt
+
 from fire.api import FireDb
-from fire.api.model import Koordinat, Artskode
+from fire.api.model import (
+    Koordinat,
+    Artskode,
+    Srid,
+    Punkt,
+    Sag,
+    Sagsevent,
+    EventType,
+)
 
 
 def test_koordinat(firedb: FireDb, koordinat: Koordinat):
@@ -9,3 +20,60 @@ def test_koordinat(firedb: FireDb, koordinat: Koordinat):
 def test_artskode(firedb: FireDb, koordinat: Koordinat):
     koordinat.artskode = Artskode.TRANSFORMERET
     firedb.session.commit()
+
+
+def test_afregistrering_af_koordinat(
+    firedb: FireDb, sag: Sag, srid: Srid, punkt: Punkt
+):
+    """
+    Database triggeren BID#KOORDINAT sætter registreringtil og sagseventtilid ved
+    indsættelse af ny koordinat. Tjek at triggeren virker.
+    """
+
+    se1 = Sagsevent(
+        id=str(uuid.uuid4()), sag=sag, eventtype=EventType.KOORDINAT_BEREGNET
+    )
+    se1.koordinater = [
+        Koordinat(
+            srid=srid,
+            punkt=punkt,
+            t=dt.datetime(2020, 5, 13, 8, 0),
+            x=0,
+            y=0,
+            z=0,
+            sx=0,
+            sy=0,
+            sz=0,
+        )
+    ]
+    firedb.session.add(se1)
+    firedb.session.commit()
+
+    se2 = Sagsevent(
+        id=str(uuid.uuid4()), sag=sag, eventtype=EventType.KOORDINAT_BEREGNET
+    )
+    se2.koordinater = [
+        Koordinat(
+            srid=srid,
+            punkt=punkt,
+            t=dt.datetime(2020, 5, 13, 9, 45),
+            x=1,
+            y=1,
+            z=1,
+            sx=1,
+            sy=1,
+            sz=1,
+        )
+    ]
+    firedb.session.add(se2)
+    firedb.session.commit()
+
+    p = firedb.hent_punkt(punkt.id)
+
+    assert len(p.koordinater) == 2
+
+    assert p.koordinater[0].srid.sridid == srid.sridid
+    assert p.koordinater[1].srid.sridid == srid.sridid
+
+    assert p.koordinater[0].registreringtil == p.koordinater[1].registreringfra
+    assert p.koordinater[0].sagseventtilid == p.koordinater[1].sagseventfraid


### PR DESCRIPTION
`_close_existing_koordinat` gør grundlæggende det samme som triggeren
BID#KOORDINAT, hvorfor funktionen er overflødig. Ved at håndtere
afregistreringen på databaseniveau sikrer vi os at der ikke indsættes
fejlbehæftet data pga fejl i kode eller brugen af API'et.

Tests tilføjet for at verificere at triggeren fungerer efter hensigten.