### PR TITLE
Generer UUID'er automatisk ved indsættelse

### DIFF
--- a/fire/__init__.py
+++ b/fire/__init__.py
@@ -1,1 +1,8 @@
+from uuid import uuid4
+
 __version__ = "0.3.0"
+
+
+def uuid():
+    """UUID generator"""
+    return str(uuid4())

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import datetime
 from typing import List, Optional
 
@@ -367,8 +366,6 @@ class FireDb(object):
             sagsevent.eventtype = eventtype
         elif sagsevent.eventtype != eventtype:
             raise Exception(f"'{sagsevent.eventtype}' sagsevent. Should be {eventtype}")
-        if sagsevent.id is None:
-            sagsevent.id = str(uuid.uuid4())
 
     def _filter_observationer(
         self,

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -4,7 +4,13 @@ from sqlalchemy.orm import relationship
 
 # DeclarativeBase = sqlalchemy.ext.declarative.declarative_base(cls=ReprBase)
 
-from fire.api.model import IntEnum, RegisteringTidObjekt, DeclarativeBase, columntypes
+import fire
+from fire.api.model import (
+    IntEnum,
+    RegisteringTidObjekt,
+    DeclarativeBase,
+    columntypes,
+)
 
 # Eksports
 __all__ = [
@@ -78,7 +84,7 @@ class FikspunktregisterObjekt(RegisteringTidObjekt):
 
 class Punkt(FikspunktregisterObjekt):
     __tablename__ = "punkt"
-    id = Column(String, nullable=False, unique=True)
+    id = Column(String, nullable=False, unique=True, default=fire.uuid)
     sagseventfraid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
     sagsevent = relationship(
         "Sagsevent", foreign_keys=[sagseventfraid], back_populates="punkter"

--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -2,7 +2,12 @@ import enum
 from sqlalchemy import Column, String, Integer, ForeignKey
 from sqlalchemy.orm import relationship
 
-from fire.api.model import RegisteringTidObjekt, RegisteringFraObjekt, DeclarativeBase
+import fire
+from fire.api.model import (
+    RegisteringTidObjekt,
+    RegisteringFraObjekt,
+    DeclarativeBase,
+)
 from fire.api.model.columntypes import IntegerEnum
 
 # Model this as a hard coded enum for now. This makes it a lot easier for the user. It would be nice to sync this with
@@ -22,7 +27,7 @@ class EventType(enum.Enum):
 
 class Sag(RegisteringFraObjekt):
     __tablename__ = "sag"
-    id = Column(String(36), nullable=False)
+    id = Column(String(36), nullable=False, default=fire.uuid)
     sagsevents = relationship(
         "Sagsevent", order_by="Sagsevent.objectid", back_populates="sag"
     )
@@ -43,7 +48,7 @@ class Sagsinfo(RegisteringTidObjekt):
 
 class Sagsevent(RegisteringFraObjekt):
     __tablename__ = "sagsevent"
-    id = Column(String(36), nullable=False)
+    id = Column(String(36), nullable=False, default=fire.uuid)
     eventtype = Column("eventtypeid", IntegerEnum(EventType), nullable=False)
     # beskrivelse = Column(String)
     sagid = Column(String(36), ForeignKey("sag.id"), nullable=False)

--- a/fire/cli/mark.py
+++ b/fire/cli/mark.py
@@ -6,12 +6,12 @@ import json
 import os
 import subprocess
 import sys
-import uuid
 
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import NoResultFound
 import click
 
+import fire
 from fire.cli import firedb
 from fire.api.model import (
     Sag,
@@ -47,7 +47,7 @@ def nyt_projekt(beskrivelse: click.STRING, output: click.File, **kwargs) -> None
     banner("OBSERVATIONSFILER", file=output)
     banner("SETUP", file=output)
     print("sagsbehandler = " + getpass.getuser(), file=output)
-    print("sagsid = " + str(uuid.uuid4()), file=output)
+    print("sagsid = " + fire.uuid(), file=output)
 
 
 def banner(bannertekst: str, **kwargs):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import uuid
 
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -37,13 +36,8 @@ def firedb():
 
 
 @pytest.fixture()
-def guid():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture()
-def sag(firedb, guid):
-    s0 = Sag(id=guid)
+def sag(firedb):
+    s0 = Sag()
     si0 = Sagsinfo(sag=s0, aktiv="true", behandler="yyy")
     firedb.session.add(si0)
     firedb.session.add(s0)
@@ -52,16 +46,16 @@ def sag(firedb, guid):
 
 
 @pytest.fixture()
-def sagsevent(firedb, sag, guid):
-    e0 = Sagsevent(id=guid, sag=sag, eventtype=EventType.KOMMENTAR)
+def sagsevent(firedb, sag):
+    e0 = Sagsevent(sag=sag, eventtype=EventType.KOMMENTAR)
     firedb.session.add(e0)
     return e0
 
 
 @pytest.fixture()
-def punkt(firedb, sagsevent, guid):
+def punkt(firedb, sagsevent):
     sagsevent.eventtype = EventType.PUNKT_OPRETTET
-    p0 = Punkt(id=guid, sagsevent=sagsevent)
+    p0 = Punkt(sagsevent=sagsevent)
     firedb.session.add(p0)
     return p0
 

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -1,5 +1,4 @@
 import pytest
-import uuid
 from fire.api import FireDb
 from fire.api.model import (
     Sagsevent,
@@ -16,7 +15,7 @@ def test_punkt(firedb: FireDb, punkt: Punkt):
 
 
 def test_indset_punkt(firedb: FireDb, sag: Sag):
-    p = Punkt(id=str(uuid.uuid4()))
+    p = Punkt()
     go = GeometriObjekt()
     go.geometri = Point([1, 1])
     p.geometriobjekter.append(go)
@@ -24,7 +23,7 @@ def test_indset_punkt(firedb: FireDb, sag: Sag):
 
 
 def test_indset_punkt_with_invalid_sagsevent_eventtype(firedb: FireDb, sag: Sag):
-    p = Punkt(id=str(uuid.uuid4()))
+    p = Punkt()
     go = GeometriObjekt()
     go.geometri = Point([1, 1])
     p.geometriobjekter.append(go)
@@ -33,8 +32,8 @@ def test_indset_punkt_with_invalid_sagsevent_eventtype(firedb: FireDb, sag: Sag)
 
 
 def test_hent_punkt(firedb: FireDb, punkt: Punkt):
-    punktid = punkt.id
     firedb.session.commit()  # sørg for at punkt indsættes i databasen
+    punktid = punkt.id
     print(punktid)
     print(punkt)
     p = firedb.hent_punkt(punktid)

--- a/test/test_sag.py
+++ b/test/test_sag.py
@@ -12,20 +12,17 @@ def test_hent_alle_sager(firedb: FireDb):
     assert len(ss) > 1
 
 
-def test_indset_sag(firedb: FireDb, guid):
+def test_indset_sag(firedb: FireDb):
     sagsinfo = Sagsinfo(aktiv="true", behandler="test")
-    sag = Sag(id=guid, sagsinfos=[sagsinfo])
+    sag = Sag(sagsinfos=[sagsinfo])
     firedb.indset_sag(sag)
 
 
-def test_indset_sagsevent(firedb: FireDb, sag: Sag, guid):
+def test_indset_sagsevent(firedb: FireDb, sag: Sag):
     sagseventinfo = SagseventInfo(beskrivelse="Testing testing")
     firedb.indset_sagsevent(
         Sagsevent(
-            id=guid,
-            sag=sag,
-            eventtype=EventType.KOMMENTAR,
-            sagseventinfos=[sagseventinfo],
+            sag=sag, eventtype=EventType.KOMMENTAR, sagseventinfos=[sagseventinfo],
         )
     )
 


### PR DESCRIPTION
Tilføjer funktionen `fire.uuid` som kaldes alle steder hvor der før blev
skabt uuid'er med `str(uuid.uuid4()). Desuden er Sag, Sagsevent og Punkt
udvidet til at automatisk indsætte et UUID som ID ved indlæsning i
databasen. Dette fjerner en del boilerplate kode ved instatiering af disse
klasser.

Closes #92