### PR TITLE
DDL opdateringer

### DIFF
--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -10,6 +10,7 @@ from fire.api.model import (
 )
 from fire.api.model.columntypes import IntegerEnum
 
+
 # Model this as a hard coded enum for now. This makes it a lot easier for the user. It would be nice to sync this with
 # the db table eventtype
 class EventType(enum.Enum):
@@ -21,8 +22,7 @@ class EventType(enum.Enum):
     PUNKTINFO_FJERNET = 6
     PUNKT_OPRETTET = 7
     PUNKT_NEDLAGT = 8
-    BEREGNING = 9
-    KOMMENTAR = 10
+    KOMMENTAR = 9
 
 
 class Sag(RegisteringFraObjekt):

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -368,7 +368,8 @@ COMMENT ON COLUMN SRIDTYPE.Y IS 'Beskrivelse af y-koordinatens indhold.';
 COMMENT ON COLUMN SRIDTYPE.Z IS 'Beskrivelse af z-koordinatens indhold.';
 
 -- Constraints og triggers ikke defineret i modellen
--- Constraint der tjekker at PUNKTID eksisterer i PUNKT tabellen inden en række sættes ind i KOORDINAT-, OBESARVATION- og PUNKTINFO-tabellen
+-- Constraint der tjekker at PUNKTID eksisterer i PUNKT tabellen inden en række
+-- sættes ind i KOORDINAT-, OBESARVATION- og PUNKTINFO-tabellen
 CREATE UNIQUE INDEX ID_IDX_0001 ON PUNKT (ID);
 
 ALTER TABLE PUNKT ADD (
@@ -394,7 +395,8 @@ UNIQUE (EVENTTYPEID)
 USING INDEX EVENTTYPE_U01
 ENABLE VALIDATE;
 
--- Index der skal sikre at der til samme punkt ikke tilføjes en koordinat med samme SRIDID, hvis denne ikke er afregistreret
+-- Index der skal sikre at der til samme punkt ikke tilføjes en koordinat
+-- med samme SRIDID, hvis denne ikke er afregistreret
 CREATE UNIQUE INDEX KOOR_UNIQ_001 ON KOORDINAT (SRIDID, PUNKTID, REGISTRERINGTIL);
 
 
@@ -509,7 +511,7 @@ CONSTRAINT SAGSINFO_CON_0001
 CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
 ENABLE VALIDATE;
 
--- Constraint der sikre at en sag eksisterer som en sagsevent referere til
+-- Constraint der sikrer at et sagsevent henviser til en eksisterende sag
 ALTER TABLE SAGSEVENT ADD
 CONSTRAINT SAGSEVENT_R01
 FOREIGN KEY (SAGID)
@@ -539,10 +541,7 @@ REFERENCES SAGSEVENT (ID)
 ENABLE VALIDATE);
 
 
-
-
-
--- Triggere der sikre at kun registreringtil kan opdateres i en tabel
+-- Triggere der sikrer at kun registreringtil kan opdateres i en tabel
 CREATE OR REPLACE TRIGGER AUD#BEREGNING
 after update ON BEREGNING
 for each row
@@ -550,9 +549,6 @@ begin
 IF :new.OBJECTID != :old.OBJECTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
 
 IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
@@ -564,14 +560,10 @@ CREATE OR REPLACE TRIGGER AUD#GEOMETRIOBJEKT
 after update ON GEOMETRIOBJEKT
 for each row
 begin
---IF :new.GEOMETRI != :old.GEOMETRI THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.OBJECTID != :old.OBJECTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-
--- IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
@@ -587,8 +579,6 @@ begin
 IF :new.OBJECTID != :old.OBJECTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
--- IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.SRIDID != :old.SRIDID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
@@ -617,7 +607,7 @@ IF :new.PUNKTID != :old.PUNKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot 
 end;
 /
 
--- Trigger der sikre at indeholdet i tabellen OBSERVATION matcher hvad der er specificeret omkring observationstypen i OBSERVATIONTYPE tabellen
+
 CREATE OR REPLACE TRIGGER AUD#OBSERVATION
 after update ON OBSERVATION
 for each row
@@ -625,8 +615,6 @@ begin
 IF :new.OBJECTID != :old.OBJECTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.ANTAL != :old.ANTAL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
@@ -675,7 +663,7 @@ IF :new.SIGTEPUNKTID != :old.SIGTEPUNKTID THEN RAISE_APPLICATION_ERROR(-20000,'Y
 end;
 /
 
--- Trigger der sikre at indeholdet i tabellen KOORDINAT matcher hvad der er specificeret omkring SRID i SRIDTYPE tabellen
+-- Trigger der sikrer at indeholdet i tabellen KOORDINAT matcher hvad der er specificeret omkring SRID i SRIDTYPE tabellen
 CREATE OR REPLACE TRIGGER AIU#KOORDINAT
 after insert Or UPDATE ON KOORDINAT
 for each row
@@ -719,8 +707,6 @@ IF :new.OBJECTID != :old.OBJECTID THEN RAISE_APPLICATION_ERROR(-20000,'You canno
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
 IF :new.ID != :old.ID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
@@ -740,8 +726,6 @@ IF :new.ID != :old.ID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update thi
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
 end;
 /
 
@@ -755,8 +739,6 @@ IF :new.OBJECTID != :old.OBJECTID THEN RAISE_APPLICATION_ERROR(-20000,'You canno
 IF :new.ID != :old.ID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(b) '); END IF;
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(c) '); END IF;
-
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.SAGID != :old.SAGID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(d) '); END IF;
 
@@ -775,8 +757,6 @@ IF :new.SAGSEVENTID != :old.SAGSEVENTID THEN RAISE_APPLICATION_ERROR(-20000,'You
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
 IF :new.BESKRIVELSE != :old.BESKRIVELSE THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 end;
@@ -793,8 +773,6 @@ IF :new.SAGID != :old.SAGID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot upda
 
 IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
---IF :new.REGISTRERINGTIL != :old.REGISTRERINGTIL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
 IF :new.AKTIV != :old.AKTIV THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
 
 IF :new.JOURNALNUMMER != :old.JOURNALNUMMER THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
@@ -807,7 +785,7 @@ end;
 /
 
 
--- Trigger der sikre at sageevents kun knyttes til en aktiv sag
+-- Trigger der sikrer at sageevents kun knyttes til en aktiv sag
 CREATE OR REPLACE TRIGGER AID#SAGSEVENT
 after insert ON SAGSEVENT
 for each row
@@ -830,8 +808,6 @@ begin
 
 end;
 /
-
-
 
 
 -- Trigger der skal sikre at inholdet i Observation-tabellen matcher hvad der er defineret observationtype-tabellen
@@ -940,8 +916,7 @@ end;
 /
 
 
-
--- Constraints der sikre at namespacedelen er korrekt i PUNKTINFOTYPE, OBSERVATIONTYPE og SRIDTYPE
+-- Constraints der sikrer at namespacedelen er korrekt i PUNKTINFOTYPE, OBSERVATIONTYPE og SRIDTYPE
 ALTER TABLE PUNKTINFOTYPE ADD
 CONSTRAINT PUNKTINFOTYPE_CON_0001
 CHECK (substr(infotype,1,instr(infotype,':')-1) in ('AFM','ATTR','IDENT','NET','PS','REGION','SKITSE'))
@@ -953,7 +928,7 @@ CONSTRAINT OT_SRID_0001
 CHECK (substr(SRID,1,instr(SRID,':')-1) in ('DK','EPSG','FO','GL','LOC','NKG','TS'))
 ENABLE VALIDATE;
 
--- Sikre at infotype i PUNKTINFO eksisterer i PUNKTINFOTYPE, og at data i PUNKTINFO matcher definition i PUNKTINFOTYPE
+-- Sikrer at infotype i PUNKTINFO eksisterer i PUNKTINFOTYPE, og at data i PUNKTINFO matcher definition i PUNKTINFOTYPE
 CREATE OR REPLACE TRIGGER PUNKTINFO_TYPE_VALID_TRG
 BEFORE INSERT OR UPDATE
 ON PUNKTINFO
@@ -1089,7 +1064,7 @@ END;
 /
 
 
--- Indehold til observationtype
+-- Indhold til observationtype
 INSERT INTO observationtype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Koteforskel fra fikspunkt1 til fikspunkt2 (h2-h1) opmålt geometrisk ', 1, 'geometrisk_koteforskel', 'true','Koteforskel [m]', 'Nivellementslængde [m]', 'Antal opstillinger', 'Variabel vedr. eta_1 (refraktion) [m^3]', 'Afstandsafhængig varians koteforskel pr. målt koteforskel [m^2/m]', 'Afstandsuafhængig varians koteforskel pr. målt koteforskel [m^2]', 'Præcisionsnivellement [0,1,2,3]', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1124,8 +1124,6 @@ END;
 /
 
 
-
-
 -- Indehold til observationtype
 INSERT INTO observationtype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Koteforskel fra fikspunkt1 til fikspunkt2 (h2-h1) opmålt geometrisk ', 1, 'geometrisk_koteforskel', 'true','Koteforskel [m]', 'Nivellementslængde [m]', 'Antal opstillinger', 'Variabel vedr. eta_1 (refraktion) [m^3]', 'Afstandsafhængig varians koteforskel pr. målt koteforskel [m^2/m]', 'Afstandsuafhængig varians koteforskel pr. målt koteforskel [m^2]', 'Præcisionsnivellement [0,1,2,3]', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -1179,10 +1177,7 @@ INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
 VALUES ('bruges når et punkt og tilhørende geometri nedlægges', 'punkt_nedlagt', 8);
 
 INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
-VALUES ('bruges når nye koordinater skabes. Knytter observationer til koordinater', 'beregning', 9);
-
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
-VALUES ('bruges til at tilføje fritekst kommentarer til sagen i tilfælde af at der er behov for at påhæfte sagen yderligere information som ikke passer i andre hændelser. Bruges fx også til påhæftning af materiale på sagen.', 'kommentar', 10);
+VALUES ('bruges til at tilføje fritekst kommentarer til sagen i tilfælde af at der er behov for at påhæfte sagen yderligere information som ikke passer i andre hændelser. Bruges fx også til påhæftning af materiale på sagen.', 'kommentar', 9);
 
 -- End
 

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -114,13 +114,6 @@ CREATE TABLE OBSERVATIONTYPE (
    VALUE15 VARCHAR2(4000)
 );
 
-CREATE TABLE OBSERVATIONTYPENAMESPACE (
-
-   OBJECTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL,
-   NAMESPACE VARCHAR2(4000) NOT NULL
-);
-
 CREATE TABLE PUNKT (
 
    OBJECTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
@@ -153,12 +146,6 @@ CREATE TABLE PUNKTINFOTYPE (
    BESKRIVELSE VARCHAR2(4000) NOT NULL
 );
 
-CREATE TABLE PUNKTINFOTYPENAMESPACE (
-
-   OBJECTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL,
-   NAMESPACE VARCHAR2(4000) NOT NULL
-);
 
 CREATE TABLE SAG (
 
@@ -212,12 +199,6 @@ CREATE TABLE SAGSINFO (
    SAGID VARCHAR2(36) NOT NULL
 );
 
-CREATE TABLE SRIDNAMESPACE (
-
-   OBJECTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   NAMESPACE VARCHAR2(4000) NOT NULL,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL
-);
 
 CREATE TABLE SRIDTYPE (
 
@@ -333,9 +314,6 @@ COMMENT ON COLUMN OBSERVATIONTYPE.VALUE6 IS 'Beskrivelse af en observations vær
 COMMENT ON COLUMN OBSERVATIONTYPE.VALUE7 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
 COMMENT ON COLUMN OBSERVATIONTYPE.VALUE8 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
 COMMENT ON COLUMN OBSERVATIONTYPE.VALUE9 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON TABLE OBSERVATIONTYPENAMESPACE IS 'Type der afgrænser de lovlige namspaces der kan anvendes i observationstype, samt en beskrivese af denne.';
-COMMENT ON COLUMN OBSERVATIONTYPENAMESPACE.BESKRIVELSE IS 'Kort beskrivelse af hvad der dækkes af et observationsnamespace.';
-COMMENT ON COLUMN OBSERVATIONTYPENAMESPACE.NAMESPACE IS 'Navn på et lovlige namspace for en observation.';
 COMMENT ON TABLE PUNKT IS 'Abstrakt repræsentation af et fysisk punkt. Knytter alle punktinformationer sammen.';
 COMMENT ON COLUMN PUNKT.ID IS 'Persistent unik nøgle.';
 COMMENT ON COLUMN PUNKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
@@ -356,9 +334,6 @@ COMMENT ON COLUMN PUNKTINFOTYPE.ANVENDELSE IS 'Er det reelTal, tekst, eller inge
 COMMENT ON COLUMN PUNKTINFOTYPE.BESKRIVELSE IS 'Beskrivelse af denne informationstypes art.';
 COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPE IS 'Arten af dette informationselement';
 COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
-COMMENT ON TABLE PUNKTINFOTYPENAMESPACE IS 'Type der afgrænser de lovlige namspaces der kan anvendes i infotype, samt en beskrivese af denne.';
-COMMENT ON COLUMN PUNKTINFOTYPENAMESPACE.BESKRIVELSE IS 'Kort beskrivelse af hvad der dækkes af et punktinfonamespace.';
-COMMENT ON COLUMN PUNKTINFOTYPENAMESPACE.NAMESPACE IS 'Navn på et lovlige namspace for en punktinformation.';
 COMMENT ON TABLE SAG IS 'Samling af administrativt relaterede sagshændelser.';
 COMMENT ON COLUMN SAG.ID IS 'Persistent unik nøgle.';
 COMMENT ON COLUMN SAG.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
@@ -384,9 +359,6 @@ COMMENT ON COLUMN SAGSINFO.JOURNALNUMMER IS 'Sagsmappeidentifikation i opmåling
 COMMENT ON COLUMN SAGSINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
 COMMENT ON COLUMN SAGSINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
 COMMENT ON COLUMN SAGSINFO.SAGID IS 'Den sag som sagsinfo holder information for.';
-COMMENT ON TABLE SRIDNAMESPACE IS 'Type der afgrænser de lovlige namspaces der kan anvendes i SRIDtype, samt en beskrivese af denne.';
-COMMENT ON COLUMN SRIDNAMESPACE.BESKRIVELSE IS 'Kort beskrivelse af hvad der dækkes af et SRIDnamespace.';
-COMMENT ON COLUMN SRIDNAMESPACE.NAMESPACE IS 'Navn på et lovlige namspace for en SRID.';
 COMMENT ON TABLE SRIDTYPE IS 'Udfaldsrum for SRID-koordinatbeskrivelser.';
 COMMENT ON COLUMN SRIDTYPE.BESKRIVELSE IS 'Generel beskrivelse af systemet.';
 COMMENT ON COLUMN SRIDTYPE.SRID IS 'Den egentlige referencesystemindikator.';
@@ -969,17 +941,10 @@ end;
 
 
 
-
 -- Constraints der sikre at namespacedelen er korrekt i PUNKTINFOTYPE, OBSERVATIONTYPE og SRIDTYPE
 ALTER TABLE PUNKTINFOTYPE ADD
 CONSTRAINT PUNKTINFOTYPE_CON_0001
 CHECK (substr(infotype,1,instr(infotype,':')-1) in ('AFM','ATTR','IDENT','NET','PS','REGION','SKITSE'))
-ENABLE
-VALIDATE;
-
-ALTER TABLE OBSERVATIONTYPE ADD
-CONSTRAINT OBSERVATIONTYPE_CON_0001
-CHECK (substr(observationstype,1,instr(observationstype,':')-1) in ('OBS'))
 ENABLE
 VALIDATE;
 

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -1217,7 +1217,7 @@ INSERT INTO sagsevent (
 ) VALUES (
     'sagevent-aaaa-bbbb-0005-000000000005',
     sysdate,
-    10, -- punkt+geometri nedlagt
+    9, -- kommentar
     'sag00005-aaaa-bbbb-cccc-000000000001'
 );
 

--- a/test/test_punktinformation.py
+++ b/test/test_punktinformation.py
@@ -7,3 +7,28 @@ from fire.api.model import (
 def test_indset_punktinformation(firedb, sag, punkt, punktinformationtype):
     pi = PunktInformation(infotype=punktinformationtype, punkt=punkt)
     firedb.indset_punktinformation(Sagsevent(sag=sag), pi)
+
+
+def test_opdatering_punktinformation(firedb, sag, punkt):
+    pit = firedb.hent_punktinformationtype("IDENT:landsnr")
+
+    se1 = Sagsevent(sag=sag)
+    pi1 = PunktInformation(infotype=pit, punkt=punkt, tekst="K-12-1231")
+    firedb.indset_punktinformation(se1, pi1)
+
+    se2 = Sagsevent(sag=sag)
+    pi2 = PunktInformation(infotype=pit, punkt=punkt, tekst="K-22-2231")
+    firedb.indset_punktinformation(se2, pi2)
+
+    infotyper = (
+        firedb.session.query(PunktInformation)
+        .filter(
+            PunktInformation.infotypeid == pit.infotypeid,
+            PunktInformation.punktid == punkt.id,
+        )
+        .all()
+    )
+
+    assert len(infotyper) == 2
+    assert infotyper[0].registreringtil == infotyper[1].registreringfra
+    assert infotyper[0].sagseventtilid == infotyper[1].sagseventfraid


### PR DESCRIPTION
- Fjerner eventtypen "beregning", da samme funktionalitet er dækket af "koordinat_beregnet". #116
- Fjerner ubrugte namespace tabeller #128
- Strammer op på kommentarer
- Tilføjer db trigger der sørger for at afregistere punktinformation korrekt ved opdatering