### PR TITLE
Mindre forbedring af dataimport

### DIFF
--- a/fire/cli/mtl.py
+++ b/fire/cli/mtl.py
@@ -635,12 +635,12 @@ def go(**kwargs) -> None:
         # -----------------------------------------------------
 
         # Først en ikke-vægtet udjævning som sammenligningsgrundlag
-        model = sm.OLS(y, X)
-        result = model.fit()
-        print("Ikke-vægtet")
-        print(result.params)
-        print(result.HC0_se)
-        print(result.summary2())
+        # model = sm.OLS(y, X)
+        # result = model.fit()
+        # print("Ikke-vægtet")
+        # print(result.params)
+        # print(result.HC0_se)
+        # print(result.summary2())
 
         # Se https://www.statsmodels.org/devel/examples/notebooks/generated/wls.html
         model = sm.WLS(y, X, weights=(P ** 2))


### PR DESCRIPTION
Der indgår nogle sære tegn i rådatafiler, steder hvor konteksten tilsiger at der skal stå "æ". Derfor disse rettelser, der primært sørger for at sikre at ind- og udlæsning  foregår med utf-8. Desværre løser det ikke problemet: Placeholdertegnene er introduceret før rådatafilen når frem til FIRE. Men præciseringen i koden har også værdi i sig selv - om ikke andet så fordi den gør det klokkeklart at problemet ligger et andet sted