### PR TITLE
Indsæt manglende rækketæller for 'holdte' punkter

### DIFF
--- a/fire/cli/mtl.py
+++ b/fire/cli/mtl.py
@@ -539,6 +539,7 @@ def designmatrix(observationer, punkter, estimerede, fastholdte, holdte):
         X.at[row, pkt] = 1
         y[row] = holdte[pkt][0]
         P[row] = 1.0 / holdte[pkt][1]
+        row += 1
 
     return X, P, y
 


### PR DESCRIPTION
Observationsligninger for holdte ("constrained") punkter overskrev hinanden, da der manglede en rækketælleropdatering. Det er fikset her