### PR TITLE
Tilføj luk_-funktioner

### DIFF
--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -35,6 +35,10 @@ class Sag(RegisteringFraObjekt):
         "Sagsinfo", order_by="Sagsinfo.objectid", back_populates="sag"
     )
 
+    @property
+    def aktiv(self) -> bool:
+        return self.sagsinfos[-1].aktiv != "false"
+
 
 class Sagsinfo(RegisteringTidObjekt):
     __tablename__ = "sagsinfo"
@@ -50,7 +54,6 @@ class Sagsevent(RegisteringFraObjekt):
     __tablename__ = "sagsevent"
     id = Column(String(36), nullable=False, default=fire.uuid)
     eventtype = Column("eventtypeid", IntegerEnum(EventType), nullable=False)
-    # beskrivelse = Column(String)
     sagid = Column(String(36), ForeignKey("sag.id"), nullable=False)
     sag = relationship("Sag", back_populates="sagsevents")
     sagseventinfos = relationship(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -120,9 +120,11 @@ def observationer(firedb, sagsevent, observationstype, punkt):
 
 
 @pytest.fixture()
-def beregning(firedb, sagsevent, observationer):
+def beregning(firedb, sagsevent, koordinat, observationer):
     sagsevent.eventtype = EventType.KOORDINAT_BEREGNET
-    b0 = Beregning(sagsevent=sagsevent, observationer=observationer)
+    b0 = Beregning(
+        sagsevent=sagsevent, observationer=observationer, koordinater=[koordinat]
+    )
     firedb.session.add(b0)
     return b0
 

--- a/test/test_koordinat.py
+++ b/test/test_koordinat.py
@@ -1,6 +1,8 @@
 import uuid
 import datetime as dt
 
+import pytest
+
 from fire.api import FireDb
 from fire.api.model import (
     Koordinat,
@@ -77,3 +79,16 @@ def test_afregistrering_af_koordinat(
 
     assert p.koordinater[0].registreringtil == p.koordinater[1].registreringfra
     assert p.koordinater[0].sagseventtilid == p.koordinater[1].sagseventfraid
+
+
+def test_luk_koordinat(firedb: FireDb, koordinat: Koordinat, sagsevent: Sagsevent):
+    firedb.session.commit()
+    assert koordinat.registreringtil is None
+    assert koordinat.sagsevent.eventtype == EventType.KOORDINAT_BEREGNET
+
+    firedb.luk_koordinat(koordinat, sagsevent)
+    assert koordinat.registreringtil is not None
+    assert koordinat.sagsevent.eventtype == EventType.KOORDINAT_NEDLAGT
+
+    with pytest.raises(TypeError):
+        firedb.luk_koordinat(firedb)

--- a/test/test_observation.py
+++ b/test/test_observation.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+import pytest
+
 from fire.api import FireDb
 from fire.api.model import (
     Sag,
@@ -8,6 +10,7 @@ from fire.api.model import (
     Observation,
     Geometry,
     ObservationType,
+    EventType,
 )
 
 
@@ -88,3 +91,18 @@ def test_indset_observation(firedb: FireDb, sag: Sag, punkt: Punkt):
         value8=0,
     )
     firedb.indset_observation(Sagsevent(sag=sag), observation)
+
+
+def test_luk_observation(
+    firedb: FireDb, observation: Observation, sagsevent: Sagsevent
+):
+    firedb.session.commit()
+    assert observation.registreringtil is None
+    assert observation.sagsevent.eventtype == EventType.OBSERVATION_INDSAT
+
+    firedb.luk_observation(observation, sagsevent)
+    assert observation.registreringtil is not None
+    assert observation.sagsevent.eventtype == EventType.OBSERVATION_NEDLAGT
+
+    with pytest.raises(TypeError):
+        firedb.luk_observation(9999)

--- a/test/test_punktinformation.py
+++ b/test/test_punktinformation.py
@@ -1,6 +1,10 @@
+from fire.api import FireDb
 from fire.api.model import (
+    Punkt,
     PunktInformation,
+    PunktInformationType,
     Sagsevent,
+    EventType,
 )
 
 
@@ -32,3 +36,21 @@ def test_opdatering_punktinformation(firedb, sag, punkt):
     assert len(infotyper) == 2
     assert infotyper[0].registreringtil == infotyper[1].registreringfra
     assert infotyper[0].sagseventtilid == infotyper[1].sagseventfraid
+
+
+def test_luk_punktinfo(
+    firedb: FireDb,
+    punktinformationtype: PunktInformationType,
+    punkt: Punkt,
+    sagsevent: Sagsevent,
+):
+    punktinfo = PunktInformation(
+        infotype=punktinformationtype, punkt=punkt, sagsevent=sagsevent
+    )
+    firedb.session.add(punktinfo)
+    firedb.session.commit()
+    assert punktinfo.registreringtil is None
+
+    firedb.luk_punktinfo(punktinfo, sagsevent)
+    assert punktinfo.registreringtil is not None
+    assert punktinfo.sagsevent.eventtype == EventType.PUNKTINFO_FJERNET

--- a/test/test_sag.py
+++ b/test/test_sag.py
@@ -1,3 +1,5 @@
+import pytest
+
 from fire.api import FireDb
 from fire.api.model import Sag, Sagsinfo, Sagsevent, SagseventInfo, EventType
 
@@ -28,3 +30,13 @@ def test_indset_sagsevent(firedb: FireDb, sag: Sag):
 
     s = firedb.hent_sag(sag.id)
     assert s.sagsevents[0].sagseventinfos[0].beskrivelse == "Testing testing"
+
+
+def test_luk_sag(firedb: FireDb, sag: Sag):
+    assert sag.aktiv is True
+    firedb.luk_sag(sag)
+    s = firedb.hent_sag(sag.id)
+    assert s.aktiv is False
+
+    with pytest.raises(TypeError):
+        firedb.luk_sag(4242)


### PR DESCRIPTION
Lukkefunktioner tilføjet for punkt, koordinat, punktinfo, observation og
beregning. Lukning af koordinater, punktinfor og observationer er
simpelt: Sæt registreringtil og sagseventtilid til noget andet end Null.
Det forholder sig anderledes med punkt og beregning. Når en beregning
lukkes, lukkes automatisk også alle tilknyttede koordinater, da de
nødvendigvis må være fejlbehæftede hvis det er nødvendigt at nedlægge en
beregning. Efter samme princip nedlægges så godt som al tilknyttet
information til et punkt når det lukkes. Det vil sige punktinfo,
kooordinater, geometriobjekt og observationer hvor punktet indgår.
Lukning af et punkt forventes kun gjort ved meget ekstraordinære
tilfælde.

Closes #23