### PR TITLE
info punkt - option til udskrivning af observationer

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -1,11 +1,14 @@
 import datetime
-import sys
 import itertools
+import math
+import sys
 
 import click
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import or_
+
+import pprint
 
 from pyproj import CRS
 
@@ -20,6 +23,157 @@ def info():
     Information om objekter i FIRE
     """
     pass
+
+
+# INSERT INTO observationtype (
+#     beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt,
+#     value1, value2, value3, value4, value5, value6, value7
+# )
+# VALUES (
+#     'Koteforskel fra fikspunkt1 til fikspunkt2 (h2-h1) opmålt geometrisk ',
+#      1,
+#     'geometrisk_koteforskel',
+#     'true',
+#
+#     'Koteforskel [m]',
+#     'Nivellementslængde [m]',
+#     'Antal opstillinger',
+#     'Variabel vedr. eta_1 (refraktion) [m^3]',
+#     'Afstandsafhængig varians koteforskel pr. målt koteforskel [m^2/m]',
+#     'Afstandsuafhængig varians koteforskel pr. målt koteforskel [m^2]',
+#     'Præcisionsnivellement [0,1,2,3]',
+# );
+#
+# INSERT INTO observationtype (
+#     beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt,
+#     value1, value2, value3, value4, value5
+# )
+# VALUES (
+#     'Koteforskel fra fikspunkt1 til fikspunkt2 (h2-h1) opmålt trigonometrisk',
+#      2,
+#     'trigonometrisk_koteforskel',
+#     'true',
+#
+#     'Koteforskel [m]',
+#     'Nivellementslængde [m]',
+#     'Antal opstillinger',
+#     'Afstandsafhængig varians pr. målt koteforskel [m^2/m^2]',
+#     'Afstandsuafhængig varians pr. målt koteforskel [m^2]',
+# );
+
+# TIL:
+# [
+#  '_decl_class_registry',
+#  '_registreringfra',
+#  '_registreringtil',
+#  '_sa_class_manager',
+#  '_sa_instance_state',
+#  'antal',
+#  'beregninger',
+#  'gruppe',
+#  'metadata',
+#  'objectid',
+#  'observationstidspunkt',
+#  'observationstype',
+#  'observationstypeid',
+#  'opstillingspunkt',
+#  'opstillingspunktid',
+#  'registreringfra',
+#  'registreringtil',
+#  'sagsevent',
+#  'sagseventfraid',
+#  'sagseventtilid',
+#  'sigtepunkt',
+#  'sigtepunktid',
+#  'slettet',
+#  'value1',
+#  'value10',
+#  'value11',
+#  'value12',
+#  'value13',
+#  'value14',
+#  'value15',
+#  'value2',
+#  'value3',
+#  'value4',
+#  'value5',
+#  'value6',
+#  'value7',
+#  'value8',
+#  'value9']
+#
+# Observation(
+#     antal=1, gruppe=71441, objectid=10342, observationstidspunkt=datetime.datetime(2003, 6, 25, 16, 7),
+#     observationstypeid=1,
+#     opstillingspunktid='61c61847-ed54-4969-b94e-df74fd63f108',
+#     sagseventfraid='A3B4DD6C-9D06-054B-E053-D380220A57E2', sagseventtilid=None,
+#     sigtepunktid='67e3987a-dc6b-49ee-8857-417ef35777af',
+#     value1=2.73728, value10=None, value11=None, value12=None, value13=None, value14=None, value15=None,
+#     value2=27.0, value3=2.0, value4=0.0, value5=6.075e-08, value6=1e-10, value7=0.0, value8=None, value9=None
+# )
+
+
+def kanonisk_ident(uuid):
+    try:
+        # TODO: Bør cache både pil, pid og resultater pr UUID, så vi kan reducere opslag
+        pil = firedb.hent_punktinformationtype("IDENT:landsnr")
+        pid = firedb.hent_punktinformationtype("IDENT:diverse")
+
+        identer = (
+            firedb.session.query(PunktInformation)
+            .filter(
+                PunktInformation.punktid == uuid,
+                or_(
+                    PunktInformation.infotypeid == pil.infotypeid,
+                    PunktInformation.infotypeid == pid.infotypeid,
+                ),
+            )
+            .all()
+        )
+        if len(identer) == 0:
+            raise NoResultFound
+
+        for ident in identer:
+            if ident.tekst.startswith("G.M."):
+                return ident.tekst
+            if ident.tekst.startswith("G.I."):
+                return ident.tekst
+        return identer[0].tekst
+
+    except NoResultFound:
+        return uuid
+
+
+def observation_linje(obs) -> str:
+    if obs.observationstypeid > 2:
+        return ""
+
+    fra = kanonisk_ident(obs.opstillingspunktid)
+    til = kanonisk_ident(obs.sigtepunktid)
+    dH = obs.value1
+    L = obs.value2
+    N = int(obs.value3)
+    tid = obs.observationstidspunkt.strftime("%Y-%m-%d %H:%M:%S")
+    oid = obs.objectid
+
+    # Geometrisk nivellement
+    if obs.observationstypeid == 1:
+        præs = int(obs.value7)
+        eta_1 = obs.value4
+        fejlfaktor = math.sqrt(obs.value5) * 1000
+        centrering = obs.value6 * 1000
+        return f"G {præs} {tid}    {dH:+09.6f} {L:05.1f} {N}    {fra:12} {til:12}    {fejlfaktor:.6f} {centrering:.6f} {eta_1:+07.2f} {oid}"
+
+    # Trigonometrisk nivellement
+    if obs.observationstypeid == 1:
+        fejlfaktor = obs.value4
+        centrering = obs.value5
+        return f"T 0 {år} {dH:+09.6f} {L:05.1f} {N}    {fra:12} {til:12}    {fejlfaktor:.6f} {centrering:.6f} {oid}"
+
+
+#     'Variabel vedr. eta_1 (refraktion) [m^3]',
+#     'Afstandsafhængig varians koteforskel pr. målt koteforskel [m^2/m]',
+#     'Afstandsuafhængig varians koteforskel pr. målt koteforskel [m^2]',
 
 
 def koordinat_linje(koord):
@@ -75,7 +229,9 @@ def koordinat_linje(koord):
     return linje
 
 
-def punkt_rapport(punkt: Punkt, ident: str, i: int, n: int) -> None:
+def punkt_rapport(
+    punkt: Punkt, ident: str, i: int, n: int, udskriv_observationer: bool = False
+) -> None:
     """
     Rapportgenerator for funktionen 'punkt' nedenfor.
     """
@@ -118,28 +274,57 @@ def punkt_rapport(punkt: Punkt, ident: str, i: int, n: int) -> None:
     fire.cli.print("--- OBSERVATIONER ---", bold=True)
     n_obs_til = len(punkt.observationer_til)
     n_obs_fra = len(punkt.observationer_fra)
+
     fire.cli.print(f"  Antal observationer til:  {n_obs_til}")
+    if udskriv_observationer:
+        punkt.observationer_til.sort(
+            key=lambda x: x.observationstidspunkt, reverse=True
+        )
+        for obs in punkt.observationer_til:
+            linje = observation_linje(obs)
+            if linje != "" and linje is not None:
+                fire.cli.print("    " + observation_linje(obs))
+        fire.cli.print("")
+
     fire.cli.print(f"  Antal observationer fra:  {n_obs_fra}")
+    if udskriv_observationer:
+        punkt.observationer_fra.sort(
+            key=lambda x: x.observationstidspunkt, reverse=True
+        )
+        for obs in punkt.observationer_fra:
+            linje = observation_linje(obs)
+            if linje != "" and linje is not None:
+                fire.cli.print("    " + observation_linje(obs))
+        fire.cli.print("")
 
     if n_obs_fra + n_obs_til > 0:
-        min_obs = datetime.datetime(9999, 12, 31)
-        max_obs = datetime.datetime(1, 1, 1)
-        for obs in itertools.chain(punkt.observationer_til, punkt.observationer_fra):
-            if obs.registreringfra < min_obs:
-                min_obs = obs.registreringfra
-            if obs.registreringfra > max_obs:
-                max_obs = obs.registreringfra
+        min_obs = datetime.datetime(9999, 12, 31, 0, 0, 0)
+        max_obs = datetime.datetime(1, 1, 1, 0, 0, 0)
+        for obs in itertools.chain(punkt.observationer_fra, punkt.observationer_til):
+            if obs.observationstidspunkt < min_obs:
+                min_obs = obs.observationstidspunkt
+            if obs.observationstidspunkt > max_obs:
+                max_obs = obs.observationstidspunkt
 
-        fire.cli.print(f"  Ældste observation     :  {min_obs}")
-        fire.cli.print(f"  Nyeste observation     :  {max_obs}")
+        fire.cli.print(f"  Ældste observation:  {min_obs}")
+        fire.cli.print(f"  Nyeste observation:  {max_obs}")
+    #        print("FRA:")
+    #        pprint.pprint(dir(punkt.observationer_fra[0]))
+    #        pprint.pprint(punkt.observationer_fra[0])
+    #        print("TIL:")
+    #        pprint.pprint(dir(punkt.observationer_til[0]))
+    #        pprint.pprint(punkt.observationer_til[0])
 
     fire.cli.print("")
 
 
 @info.command()
+@click.option(
+    "-O", "--obs", is_flag=True, default=False, help="Udskriv observationer",
+)
 @fire.cli.default_options()
 @click.argument("ident")
-def punkt(ident: str, **kwargs) -> None:
+def punkt(ident: str, obs: bool, **kwargs) -> None:
     """
     Vis al tilgængelig information om et fikspunkt
 
@@ -169,14 +354,15 @@ def punkt(ident: str, **kwargs) -> None:
             raise NoResultFound
 
         for i in range(n):
-            punkt_rapport(punktinfo[i].punkt, ident, i + 1, n)
+            punkt_rapport(punktinfo[i].punkt, ident, i + 1, n, obs)
+
     except NoResultFound:
         try:
             punkt = firedb.hent_punkt(ident)
         except NoResultFound:
             fire.cli.print(f"Error! {ident} not found!", fg="red", err=True)
             sys.exit(1)
-        punkt_rapport(punkt, ident, 1, 1)
+        punkt_rapport(punkt, ident, 1, 1, obs)
 
 
 @info.command()

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -338,10 +338,11 @@ def koordinatrapport(koordinater: List[Koordinat], options: str) -> None:
     ts = True if "ts" in options.split(",") else False
     alle = True if "alle" in options.split(",") else False
     for koord in koordinater:
-        if koord.srid.name.startswith("TS:") and options != "ts":
+        tskoord = koord.srid.name.startswith("TS:")
+        if tskoord and not ts:
             continue
         if koord.registreringtil is not None:
-            if alle:
+            if alle or (ts and tskoord):
                 fire.cli.print(". " + koordinat_linje(koord), fg="red")
         else:
             fire.cli.print("* " + koordinat_linje(koord), fg="green")
@@ -553,9 +554,9 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
         ident = f"{herred}-{sogn:02}-{lbnr:05}"
 
     # Forsøg at finde et bedre bud hvis identen er en UUID
-    uuidmønster = re.compile("[a-f0-9]*-[a-f0-9]*-[a-f0-9]*-[a-f0-9]*-[a-f0-9]*$")
-    if uuidmønster.match(ident):
-        ident = kanonisk_ident(ident)
+    # uuidmønster = re.compile("[a-f0-9]*-[a-f0-9]*-[a-f0-9]*-[a-f0-9]*-[a-f0-9]*$")
+    # if uuidmønster.match(ident):
+    #     ident = kanonisk_ident(ident)
 
     try:
         pinfo = (
@@ -586,7 +587,7 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
                 pkt = firedb.hent_punkt(ident)
                 if pkt is None:
                     raise NoResultFound
-                punkt_fuld_rapport(pkt, ident, 1, 1, obs, koord)
+                punkt_fuld_rapport(pkt, ident, 1, 1, obs, koord, detaljeret)
                 sys.exit(0)
         except NoResultFound:
             fire.cli.print(f"Error! {ident} not found!", fg="red", err=True)


### PR DESCRIPTION
Fungerer i det store hele for nivellementsobservationer (som er hvad @majbrittws har brug for lige nu), men afstandsafhængig varians ser underlig ud @kbevers kan du pege mig i retning af migreringskoden for det? - der må være noget galt.

Desuden er jeg stødt på et par mærkelige observationer, der hævder at bestå af -31072 opstillinger:

` fire info punkt -O K-63-09007`:

```
--- OBSERVATIONER ---
  Antal observationer til:  4
    G 0 1997-07-15 12:00:00    +1.125000 100.0 10    K-63-09004   K-63-09007      1.581139 0.001000 +000.00
    G 0 1997-05-23 18:02:00    +2.289700 029.1 -31072    G.M.901      K-63-09007      0.170587 0.000000 +000.00
    G 0 1997-02-19 12:00:00    +0.441000 100.0 10    K-63-09010   K-63-09007      1.581139 0.001000 +000.00
    G 3 1988-04-15 11:18:00    +2.288820 029.9 1    G.M.901      K-63-09007      0.103750 0.000000 +511.00

  Antal observationer fra:  3
    G 0 1997-05-23 18:04:00    -2.289800 028.0 -31072    K-63-09007   G.M.901         0.167332 0.000000 +000.00
    G 0 1997-02-19 12:00:00    -0.421000 030.0 10    K-63-09007   K-63-09271      0.866025 0.001000 +000.00
    G 3 1988-04-15 11:23:00    -2.289070 030.0 1    K-63-09007   G.M.901         0.103923 0.000000 -515.00

  Ældste observation:  1988-04-15 11:18:00
  Nyeste observation:  1997-07-15 12:00:00
```
