### PR TITLE
Tag punktinfotype i betragtning ved ident-opslag

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -160,6 +160,7 @@ def punkt(ident: str, **kwargs) -> None:
     try:
         punktinfo = (
             firedb.session.query(pi)
+            .join(pit)
             .filter(
                 pit.name.startswith("IDENT:"),
                 or_(


### PR DESCRIPTION
Ansporet af at

    fire info punkt G.M.902

returnerede det samme punkt to gange. Årsagen til dette skal findes i,
at punktet har en ATTR:beskrivelse der starter med "G.M.902". Da der
manglede et join på punktinfotype blev denne ikke sorteret fra. Nu tages
kun punktinfo af typen "IDENT:..." i betragtning, som det hele tiden var
intentionen.

Fixes #152