### PR TITLE
Indfør caching i FireDb.hent_punktinformationtype

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -44,6 +44,11 @@ class FireDb(object):
             if True, the SQLALchemy Engine will log all statements as well as a repr() of their parameter lists to the
             engines logger, which defaults to sys.stdout
         """
+
+        self._cache = {
+            "punktinfotype": {},
+        }
+
         self.dialect = "oracle+cx_oracle"
         self.config = self._read_config()
         if connectionstring:
@@ -232,12 +237,16 @@ class FireDb(object):
         return self.session.query(Srid).filter(Srid.name.ilike(like_filter)).all()
 
     def hent_punktinformationtype(self, infotype: str):
-        typefilter = infotype
-        return (
-            self.session.query(PunktInformationType)
-            .filter(PunktInformationType.name == typefilter)
-            .first()
-        )
+        if infotype not in self._cache["punktinfotype"]:
+            typefilter = infotype
+            pit = (
+                self.session.query(PunktInformationType)
+                .filter(PunktInformationType.name == typefilter)
+                .first()
+            )
+            self._cache["punktinfotype"][infotype] = pit
+
+        return self._cache["punktinfotype"][infotype]
 
     def hent_punktinformationtyper(self, namespace: Optional[str] = None):
         if not namespace:

--- a/test/test_punktinformationtype.py
+++ b/test/test_punktinformationtype.py
@@ -39,3 +39,10 @@ def test_hent_punktinformationtyper_for_namespace(firedb):
     all = list(firedb.hent_punktinformationtyper())
     filter = list(firedb.hent_punktinformationtyper(namespace="ATTR"))
     assert len(all) > len(filter)
+
+
+def test_punktinfotype_cache(firedb):
+    pit1 = firedb.hent_punktinformationtype("NET:TEST")
+    pit2 = firedb.hent_punktinformationtype("NET:TEST")
+
+    assert pit1 is pit2


### PR DESCRIPTION
Der kan potentielt laves mange kald for at få det samme objekt ud af
databasen. Nu caches de up front, så der ikke spildes unødig tid på
databaseopslag der ikke er nødvendige.