### PR TITLE
Tilføjelse af Boolean enum

### DIFF
--- a/fire/api/gama/reader.py
+++ b/fire/api/gama/reader.py
@@ -68,7 +68,6 @@ class GamaReader(object):
             koordinat.srid = srid
             koordinat.z = z
             koordinat.sz = std_dev
-            koordinat.transformeret = "false"
             koordinat.punkt = self.fireDb.hent_punkt(point_id)
             beregning.koordinater.append(koordinat)
 

--- a/fire/api/model/__init__.py
+++ b/fire/api/model/__init__.py
@@ -4,10 +4,13 @@ import sqlalchemy.ext.declarative
 from sqlalchemy import Column, Integer, DateTime, String, func
 
 
-class IntEnum(sqlalchemy.types.TypeDecorator):
-    """Add an integer enum class"""
+class BetterBehavedEnum(sqlalchemy.types.TypeDecorator):
+    """
+    SQLAlchemy ignorer som standard værdierne i tilknyttet labels i en Enum.
+    Denne klasse sørger for at de korrekte værdier indsættes, sådan at
 
-    impl = sqlalchemy.Integer
+    Boolean.FALSE oversættes til 'false' og ikke 'FALSE'.
+    """
 
     def __init__(self, enumtype, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -18,6 +21,18 @@ class IntEnum(sqlalchemy.types.TypeDecorator):
 
     def process_result_value(self, value, dialect):
         return self._enumtype(value)
+
+
+class IntEnum(BetterBehavedEnum):
+    """Add an integer enum class"""
+
+    impl = sqlalchemy.Integer
+
+
+class StringEnum(BetterBehavedEnum):
+    """Add an integer enum class"""
+
+    impl = sqlalchemy.String
 
 
 class ReprBase(object):

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import relationship
 import fire
 from fire.api.model import (
     IntEnum,
+    StringEnum,
     RegisteringTidObjekt,
     DeclarativeBase,
     columntypes,
@@ -26,6 +27,7 @@ __all__ = [
     "PunktInformationType",
     "PunktInformationTypeAnvendelse",
     "Srid",
+    "Boolean",
 ]
 
 
@@ -33,6 +35,11 @@ class PunktInformationTypeAnvendelse(enum.Enum):
     FLAG = "FLAG"
     TAL = "TAL"
     TEKST = "TEKST"
+
+
+class Boolean(enum.Enum):
+    TRUE = "true"
+    FALSE = "false"
 
 
 class Artskode(enum.Enum):
@@ -195,7 +202,7 @@ class Koordinat(FikspunktregisterObjekt):
     sy = Column(Float)
     sz = Column(Float)
     t = Column(DateTime(timezone=True))
-    transformeret = Column(String, nullable=False, default="false")
+    transformeret = Column(StringEnum(Boolean), nullable=False, default=Boolean.FALSE)
     artskode = Column(IntEnum(Artskode), nullable=True, default=Artskode.NULL)
     x = Column(Float)
     y = Column(Float)
@@ -276,7 +283,7 @@ class ObservationType(DeclarativeBase):
     value13 = Column(String)
     value14 = Column(String)
     value15 = Column(String)
-    sigtepunkt = Column(String(5), nullable=False)
+    sigtepunkt = Column(StringEnum(Boolean), nullable=False, default=Boolean.FALSE)
     observationer = relationship(
         "Observation",
         order_by="Observation.objectid",

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -20,6 +20,7 @@ from fire.api.model import (
     PunktInformationType,
     Koordinat,
     Observation,
+    Boolean,
 )
 
 
@@ -85,7 +86,7 @@ def koordinat_linje(koord: Koordinat) -> str:
     enhed og proveniens.
     """
     native_or_transformed = "t"
-    if koord.transformeret == "false":
+    if koord.transformeret == Boolean.FALSE:
         native_or_transformed = "n"
 
     meta = f"{koord.t.strftime('%Y-%m-%d %H:%M')}  {koord.srid.name:<15.15} {native_or_transformed} "

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,9 +41,12 @@ class TestFireDb(FireDb):
         return f"{username}:{password}@{hostname}:{port}/{database}"
 
 
+persistent_firedb = TestFireDb(debug=False)
+
+
 @pytest.fixture
 def firedb():
-    return TestFireDb(debug=False)
+    return persistent_firedb
 
 
 @pytest.fixture()
@@ -75,16 +78,7 @@ def punkt(firedb, sagsevent):
 def koordinat(firedb, sagsevent, punkt, srid):
     sagsevent.eventtype = EventType.KOORDINAT_BEREGNET
     k0 = Koordinat(
-        sagsevent=sagsevent,
-        punkt=punkt,
-        transformeret="false",
-        srid=srid,
-        x=0,
-        y=0,
-        z=0,
-        sx=0,
-        sy=0,
-        sz=0,
+        sagsevent=sagsevent, punkt=punkt, srid=srid, x=0, y=0, z=0, sx=0, sy=0, sz=0,
     )
     firedb.session.add(k0)
     return k0

--- a/test/test_beregning.py
+++ b/test/test_beregning.py
@@ -12,6 +12,7 @@ from fire.api.model import (
     Srid,
     ObservationType,
     EventType,
+    Boolean,
 )
 
 
@@ -33,9 +34,7 @@ def test_indset_beregning(
     firedb.indset_observation(Sagsevent(sag=sag), o0)
     beregning = Beregning()
     beregning.observationer.append(o0)
-    koordinat = Koordinat(
-        srid=srid, transformeret="false", punkt=punkt, x=0, y=0, z=0, sx=0, sy=0, sz=0
-    )
+    koordinat = Koordinat(srid=srid, punkt=punkt, x=0, y=0, z=0, sx=0, sy=0, sz=0)
     beregning.koordinater.append(koordinat)
     firedb.indset_beregning(Sagsevent(sag=sag), beregning)
 
@@ -48,18 +47,14 @@ def test_indset_beregning_invalidates_existing_koordinat(
     firedb.indset_observation(Sagsevent(sag=sag), observation)
     beregning = Beregning()
     beregning.observationer.append(observation)
-    koordinat = Koordinat(
-        srid=srid, transformeret="false", punkt=punkt, x=0, y=0, z=0, sx=0, sy=0, sz=0
-    )
+    koordinat = Koordinat(srid=srid, punkt=punkt, x=0, y=0, z=0, sx=0, sy=0, sz=0)
     beregning.koordinater.append(koordinat)
     firedb.indset_beregning(Sagsevent(sag=sag), beregning)
 
     # new beregning of the same observation with a new koordinat
     beregning2 = Beregning()
     beregning2.observationer.append(observation)
-    koordinat2 = Koordinat(
-        srid=srid, transformeret="false", punkt=punkt, x=1, y=0, z=0, sx=0, sy=0, sz=0,
-    )
+    koordinat2 = Koordinat(srid=srid, punkt=punkt, x=1, y=0, z=0, sx=0, sy=0, sz=0,)
     beregning2.koordinater.append(koordinat2)
     firedb.indset_beregning(Sagsevent(sag=sag), beregning2)
 

--- a/test/test_observationtype.py
+++ b/test/test_observationtype.py
@@ -1,5 +1,5 @@
 from fire.api import FireDb
-from fire.api.model import ObservationType
+from fire.api.model import ObservationType, Boolean
 
 
 def test_hent_observationtype(firedb: FireDb):
@@ -18,7 +18,7 @@ def test_indset_observationtype(firedb: FireDb):
         name="absolut_tyngde",
         beskrivelse="Absolut gravimetrisk observation",
         value1="tyngdeacceleration",
-        sigtepunkt="false",
+        sigtepunkt=Boolean.FALSE,
     )
     firedb.indset_observationtype(ot)
     typ = firedb.hent_observationtype("absolut_tyngde")


### PR DESCRIPTION
Indeholder to commits:

Første commit i dette PR sørger for at test-suiten afvikles mere effektivt. 

Andet commits indfører en Boolean enum. Istedet for at API-brugeren skal gættes sig til korrekt stavning af enten 'true' eller 'false' indføres en Boolean enum istedet.

