### PR TITLE
Info sag

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -132,9 +132,20 @@ class FireDb(object):
         return self.session.query(Punkt).all()
 
     def hent_sag(self, sagid: str) -> Sag:
-        return self.session.query(Sag).filter(Sag.id == sagid).one()
+        """
+        Hent en sag ud fra dens sagsid.
 
-    def hent_alle_sager(self) -> List[Sag]:
+        Sagsid'er behøver ikke være fuldstændige, funktionen forsøger at matche
+        partielle sagsider i samme stil som git håndterer commit hashes. I
+        tilfælde af at søgningen med et partielt sagsid resulterer i flere
+        matches udsendes en sqlalchemy.orm.exc.MultipleResultsFound exception.
+        """
+        return self.session.query(Sag).filter(Sag.id.ilike(f"{sagid}%")).one()
+
+    def hent_alle_sager(self, aktive=True) -> List[Sag]:
+        """
+        Henter alle sager fra databasen.
+        """
         return self.session.query(Sag).all()
 
     def soeg_geometriobjekt(self, bbox) -> List[GeometriObjekt]:

--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -39,6 +39,18 @@ class Sag(RegisteringFraObjekt):
     def aktiv(self) -> bool:
         return self.sagsinfos[-1].aktiv != "false"
 
+    @property
+    def journalnummer(self) -> str:
+        return self.sagsinfos[-1].journalnummer
+
+    @property
+    def behandler(self) -> str:
+        return self.sagsinfos[-1].behandler
+
+    @property
+    def beskrivelse(self) -> str:
+        return self.sagsinfos[-1].beskrivelse
+
 
 class Sagsinfo(RegisteringTidObjekt):
     __tablename__ = "sagsinfo"
@@ -132,6 +144,10 @@ class Sagsevent(RegisteringFraObjekt):
         back_populates="slettet",
         foreign_keys="Beregning.sagseventtilid",
     )
+
+    @property
+    def beskrivelse(self) -> str:
+        return self.sagseventinfos[-1].beskrivelse
 
 
 class SagseventInfo(RegisteringTidObjekt):


### PR DESCRIPTION
Kan bruges til både at få et overblik over sager i FIRE, samt detaljeret
info om en specifik sag. Eksempler herunder. `fire info sag` viser i øjeblikket alle sager, det bør nok i fremtiden ændres til kun at vise åbne sager. Det er ikke aktuelt lige nu, da antallet af sagen begrænser sig til 4...

Derudover tilføjet et par convenience funktionaliteter i API'et.

```
C:\dev\fire>fire info sag
Sagsid     Behandler           Beskrivelse
---------  ------------------  -----------
4f8f29c8:  Thomas Knudsen      Sagen er oprette i forbindelse med migrering af data fra REFGEO til FI...
a3e76ad0:  Kristian Evers      Registrering af punkter der indgik i den oprindelige DVR90-udjævning....
f0dea5cf:  Kristian Evers      Registrering af punkter der er fundamentalpunkter i et eller flere ref...
6baaf540:  Kristian Evers      Indsættelse af GR96/UTM24 koordinater.  Koordinaterne indsættes i FIRE...
```
og
```
C:\dev\fire>fire info sag a3e
------------------------- SAG -------------------------
  Sagsid        : a3e76ad0-7f47-4e50-8f9e-d5ca8c4aacd3
  Oprettet      : 2020-04-20 09:43:26
  Sagsbehandler : Kristian Evers
  Status        : Lukket
  Beskrivelse   :

    Registrering af punkter der indgik i den oprindelige DVR90-udjævning.
    Punkterne markeres med NET:DVR90.  Se "Klaus Schmidt, 2000, The Danish
    height system DVR90" for yderligere information om udjævningen.

[2020-04-20 09:51:53] PUNKTINFO_TILFØJET: Indsættelse af NET:DVR90 attibutter