### PR TITLE
MTL: GeoJSON for punkter og observationer

### DIFF
--- a/fire/cli/mtl.py
+++ b/fire/cli/mtl.py
@@ -1,6 +1,5 @@
 # Python infrastrukturelementer
 import json
-import pprint
 import subprocess
 import sys
 
@@ -365,7 +364,6 @@ def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
             delta = punkter.at[i, "Δ"]
             kote = punkter.at[i, "ny"]
             sigma = punkter.at[i, "ny σ"]
-        print(f"{punkt} {delta} {kote} {sigma} {fastholdt}")
 
         # Endnu uberegnede punkter
         if kote is None:


### PR DESCRIPTION
Skriver observationer og punkter med relevante attributter til to geojsonfiler.

Overvejede at bruge Fiona, mhp at kunne vælge vilkårligt outputformat frem for blot geojson. Men Fiona er klart lettere at bruge til at læse og forlænge med, end til at skrive nye filer fra bunden. Så det kommer først til at ske når der viser sig et oplagt behov. Koden her er tilstrækkelig kompakt og lokaliseret til at den ved den lejlighed kan fjernes med brækjern og give plads til Fionas fine fingre.