### PR TITLE
fire info sag: Undgå exceptions når beskrivelser ikke findes

### DIFF
--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -49,6 +49,8 @@ class Sag(RegisteringFraObjekt):
 
     @property
     def beskrivelse(self) -> str:
+        if self.sagsinfos[-1].beskrivelse is None:
+            return ""
         return self.sagsinfos[-1].beskrivelse
 
 
@@ -147,6 +149,8 @@ class Sagsevent(RegisteringFraObjekt):
 
     @property
     def beskrivelse(self) -> str:
+        if self.sagseventinfos[-1].beskrivelse is None:
+            return ""
         return self.sagseventinfos[-1].beskrivelse
 
 

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -569,13 +569,5 @@ def sag(sagsid: str, **kwargs):
     fire.cli.print("Sagsid     Behandler           Beskrivelse", bold=True)
     fire.cli.print("---------  ------------------  -----------")
     for sag in sager:
-        beskrivelse = (
-            sag.sagsinfos[-1]
-            .beskrivelse[0:70]
-            .strip()
-            .replace("\n", " ")
-            .replace("\r", "")
-        )
-        fire.cli.print(
-            f"{sag.id[0:8]}:  {sag.sagsinfos[-1].behandler:20}{beskrivelse}..."
-        )
+        beskrivelse = sag.beskrivelse[0:70].strip().replace("\n", " ").replace("\r", "")
+        fire.cli.print(f"{sag.id[0:8]}:  {sag.behandler:20}{beskrivelse}...")


### PR DESCRIPTION
Sagsinfo.beskrivelse og Sagsevent.beskrivelse må gerne være tomme,
derfor indføres der et par tjeks der undgår exceptions når de er tomme.

Opfølgning på #174 der altså ikke var helt færdig alligevel