### PR TITLE
MTL: Reparer API-anvendelse, citationstegn o.a.

### DIFF
--- a/fire/cli/mtl.py
+++ b/fire/cli/mtl.py
@@ -244,7 +244,6 @@ def importer_observationer(projektnavn: str) -> pd.DataFrame:
     fra = list(observationer["fra"])
     til = list(observationer["til"])
     observerede_punkter = tuple(set(fra + til))
-
     kanonisk_ident = {}
 
     for punktnavn in observerede_punkter:
@@ -254,17 +253,12 @@ def importer_observationer(projektnavn: str) -> pd.DataFrame:
         except NoResultFound:
             fire.cli.print(f"Ukendt punkt: '{punktnavn}'", fg="red", bg="white")
             sys.exit(1)
+        kanonisk_ident[punktnavn] = ident
 
-        if ident != punktnavn:
-            kanonisk_ident[punktnavn] = ident
-
-    for ident, kanon in kanonisk_ident.items():
-        hvor = [idx for idx, val in enumerate(fra) if val == ident]
-        for i in hvor:
-            fra[i] = kanon
-        hvor = [idx for idx, val in enumerate(til) if val == ident]
-        for i in hvor:
-            til[i] = kanon
+    for i in range(len(fra)):
+        fra[i] = kanonisk_ident[fra[i]]
+    for i in range(len(til)):
+        til[i] = kanonisk_ident[til[i]]
 
     observationer["fra"] = fra
     observationer["til"] = til

--- a/fire/cli/mtl.py
+++ b/fire/cli/mtl.py
@@ -25,15 +25,7 @@ import fire.cli
 from fire.cli import firedb
 
 # Typingelementer fra databaseAPIet.
-from fire.api.model import (
-    Punkt,
-    Koordinat,
-    PunktInformation,
-    PunktInformationType,
-    Sag,
-    Sagsevent,
-    Sagsinfo,
-)
+from fire.api.model import Punkt, Koordinat, PunktInformation, PunktInformationType
 
 
 # ------------------------------------------------------------------------------
@@ -112,14 +104,6 @@ def get_observation_strings(
         except FileNotFoundError:
             fire.cli.print(f"Kunne ikke læse filen '{filnavn}''")
     return observationer
-
-
-# ------------------------------------------------------------------------------
-def punkt_geometri(punkt: Punkt) -> Tuple[float, float]:
-    """Find placeringskoordinat for punkt"""
-    if len(punkt.geometriobjekter) == 0:
-        return (11, 56)
-    return tuple(punkt.geometriobjekter[-1].geometri.__geo_interface__["coordinates"])
 
 
 # ------------------------------------------------------------------------------
@@ -436,10 +420,9 @@ def opbyg_punktoversigt(
         punktoversigt.at[punkt, "σ"] = kote.sz
         punktoversigt.at[punkt, "år"] = kote.registreringfra.year
 
-        (λ, φ) = punkt_geometri(pkt)
         if pd.isna(punktoversigt.at[punkt, "φ"]):
-            punktoversigt.at[punkt, "φ"] = φ
-            punktoversigt.at[punkt, "λ"] = λ
+            punktoversigt.at[punkt, "φ"] = pkt.geometri.koordinater[1]
+            punktoversigt.at[punkt, "λ"] = pkt.geometri.koordinater[0]
 
     # Nyetablerede punkter er ikke i databasen, så hent eventuelle manglende
     # koter og placeringskoordinater i fanebladet 'Nyetablerede punkter'


### PR DESCRIPTION
Opfølgning på #172, især animeret af meget nyttige kommentarer fra @kbevers
 
Reparationer af fejl og uhensigtsmæssigheder der enten skyldes
committerens personlige tåbelighed, manglende apriorierfaring
med forskellige elementer af Python herself, eller hændelige
uheld i implementeringsfasen.

* Anvend Punkt-objektet direkte, frem for at stige hele vejen ned i
  fire.cli.firedb-objektet hver gang en lille del skal fremfindes.

* Ombyt anvendelse af enkelt- og dobbeltcitationstegn i f-strenge,
  så det matcher Blacks forkærlighed for de dobbelte

* Indfør a priori check for om uddatafil er låst af Excel