### PR TITLE
Caching af punkter og indførelse af FireDb.hent_punkt_liste()

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -89,6 +89,25 @@ class FireDb(object):
 
         return self._cache["punkt"][ident]
 
+    def hent_punkt_liste(
+        self, identer: List[str], ignorer_ukendte: bool = True
+    ) -> List[Punkt]:
+        """
+        Returnerer en liste af punkter der matcher identerne i listen `identer`.
+
+        Hvis `ignorer_ukendte` sættes til False udløses en ValueError exception
+        hvis et ident ikke kan matches med et Punkt i databasen.
+        """
+        punkter = []
+        for ident in identer:
+            try:
+                punkter.append(self.hent_punkt(ident))
+            except NoResultFound:
+                if not ignorer_ukendte:
+                    raise ValueError(f"Ident {ident} ikke fundet i databasen")
+
+        return punkter
+
     def hent_punkter(self, ident: str) -> List[Punkt]:
         """
         Returnerer alle punkter der matcher 'ident'

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -47,6 +47,7 @@ class FireDb(object):
         """
 
         self._cache = {
+            "punkt": {},
             "punktinfotype": {},
         }
 
@@ -80,7 +81,13 @@ class FireDb(object):
 
         Hvis intet punkt findes udsendes en NoResultFound exception.
         """
-        return self.hent_punkter(ident)[0]
+        if ident not in self._cache["punkt"].keys():
+            punkt = self.hent_punkter(ident)[0]
+            for idt in punkt.identer:
+                self._cache["punkt"][idt] = punkt
+            self._cache["punkt"][punkt.id] = punkt
+
+        return self._cache["punkt"][ident]
 
     def hent_punkter(self, ident: str) -> List[Punkt]:
         """

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
 import enum
+from typing import List
+
 from sqlalchemy import Table, Column, String, Integer, Float, DateTime, ForeignKey, Enum
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, reconstructor
 
 import fire
 from fire.api.model import (
@@ -26,6 +29,7 @@ __all__ = [
     "PunktInformationTypeAnvendelse",
     "Srid",
     "Boolean",
+    "Ident",
 ]
 
 
@@ -123,48 +127,59 @@ class Punkt(FikspunktregisterObjekt):
         foreign_keys="Observation.sigtepunktid",
     )
 
+    @reconstructor
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._identer = []
+
+    def _populer_identer(self):
+        """
+        Skab liste med ident-punktinformationer tilhørende punktet.
+        """
+        if not self._identer:
+            temp = []
+            for punktinfo in self.punktinformationer:
+                if punktinfo.infotype.name.startswith("IDENT:"):
+                    temp.append(Ident(punktinfo))
+
+            self._identer = sorted(temp)
+
     @property
     def geometri(self):
         return self.geometriobjekter[-1]
+
+    @property
+    def identer(self) -> List[str]:
+        """
+        Returner liste over alle identer der er tilknyttet Punktet
+        """
+        self._populer_identer()
+        return [str(ident) for ident in self._identer]
 
     @property
     def ident(self) -> str:
         """
         Udtræk det geodætisk mest læsbare ident.
 
-        I nævnte rækkefølge: Klassisk GM-, GI- eller GS-nummer,
-        GNSS-navn, eller landsnummer.
+        I nævnte rækkefølge:
+            - IDENT:GI
+            - IDENT:GNSS,
+            - IDENT:landsr
+            - IDENT:jessen
+            - IDENT:station
+            - IDENT:ekstern
+            - IDENT:diverse
+            - IDENT:refgeo_id.
 
-        Hvis et punkt hverken har et klassisk nummer eller et GNSS-navn,
-        så returneres landsnummeret. Hvis det end ikke har et landsnummer
-        så returneres uuiden uforandret.
+        Hvis et punkt overhovedet ikke har noget ident returneres uuiden
+        uforandret.
         """
+        self._populer_identer()
 
-        identer = []
-        for punktinfo in self.punktinformationer:
-            if punktinfo.infotype.name.startswith("IDENT:"):
-                identer.append(punktinfo)
-
-        for ident in identer:
-            if ident.tekst.startswith("G.M."):
-                return ident.tekst
-        for ident in identer:
-            if ident.tekst.startswith("G.I."):
-                return ident.tekst
-        for ident in identer:
-            if ident.tekst.startswith("G.S."):
-                return ident.tekst
-        for ident in identer:
-            if ident.infotype.name == "IDENT:GNSS":
-                return ident.tekst
-        for ident in identer:
-            if ident.infotype.name == "IDENT:landsnr":
-                return ident.tekst
-        for ident in identer:
-            if ident.infotype.name == "IDENT:diverse":
-                return ident.tekst
-
-        return self.id
+        try:
+            return str(self._identer[0])
+        except IndexError:
+            return self.id
 
 
 class PunktInformation(FikspunktregisterObjekt):
@@ -185,6 +200,75 @@ class PunktInformation(FikspunktregisterObjekt):
     tekst = Column(String(4000))
     punktid = Column(String(36), ForeignKey("punkt.id"), nullable=False)
     punkt = relationship("Punkt", back_populates="punktinformationer")
+
+
+class Ident:
+    class IdentType(enum.Enum):
+        GI = 1
+        GNSS = 2
+        LANDSNR = 3
+        JESSEN = 4
+        STATION = 5
+        EKSTERN = 6
+        DIVERSE = 7
+        REFGEO = 8
+        UKENDT = 9
+
+    def __init__(self, punktinfo: PunktInformation):
+        if not punktinfo.infotype.name.startswith("IDENT:"):
+            raise ValueError("punktinfo indeholder ikke en ident")
+
+        self.variant = punktinfo.infotype.name
+        self.tekst = punktinfo.tekst
+
+    def __lt__(self, other: Ident):
+        """
+        Bruges til at sortere identer med sorted().
+
+        IdentType definerer rangordenen blandt de forskellige typer identer.
+        """
+        # jo lavere værdi, des bedre ident
+        if self._type.value == other._type.value:
+            # hvis samme type, sammenligner vi på selve identen istedet
+            if self.tekst < other.tekst:
+                return True
+            else:
+                return False
+
+        if self._type.value < other._type.value:
+            return True
+        else:
+            return False
+
+    def __eq__(self, other: Ident):
+        return self.tekst == str(other)
+
+    def __str__(self):
+        return self.tekst
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}<{self.variant}: {self.tekst}>"
+
+    @property
+    def _type(self) -> IdentType:
+        if self.variant == "IDENT:GI":
+            return self.IdentType.GI
+        if self.variant == "IDENT:GNSS":
+            return self.IdentType.GNSS
+        if self.variant == "IDENT:landsnr":
+            return self.IdentType.LANDSNR
+        if self.variant == "IDENT:jessen":
+            return self.IdentType.JESSEN
+        if self.variant == "IDENT:station":
+            return self.IdentType.STATION
+        if self.variant == "IDENT:ekstern":
+            return self.IdentType.EKSTERN
+        if self.variant == "IDENT:diverse":
+            return self.IdentType.DIVERSE
+        if self.variant == "IDENT:refgeo_id":
+            return self.IdentType.REFGEO
+
+        return self.IdentType.UKENDT
 
 
 class PunktInformationType(DeclarativeBase):

--- a/test/test_ident.py
+++ b/test/test_ident.py
@@ -1,0 +1,55 @@
+import pytest
+
+from fire.api.model import (
+    PunktInformation,
+    PunktInformationType,
+    PunktInformationTypeAnvendelse,
+    Ident,
+)
+
+
+def lav_ident(variant, ident):
+    pit = PunktInformationType(
+        name=variant,
+        anvendelse=PunktInformationTypeAnvendelse.TEKST,
+        beskrivelse="Bare en test",
+    )
+    return Ident(PunktInformation(infotype=pit, tekst=ident))
+
+
+def test_ident_sortering():
+    gi = lav_ident("IDENT:GI", "G.M.902")
+    gnss = lav_ident("IDENT:GNSS", "SKEJ")
+    gnss2 = lav_ident("IDENT:GNSS", "AAAA")
+    landsnr = lav_ident("IDENT:landsnr", "102-08-00802")
+    jessen = lav_ident("IDENT:jessen", "81412")
+    station = lav_ident("IDENT:station", "1321")
+    ekstern = lav_ident("IDENT:ekstern", "88-01-2342")
+    diverse = lav_ident("IDENT:diverse", "flaf")
+    refgeoid = lav_ident("IDENT:refgeo_id", "12345")
+
+    assert [gi, gnss, jessen] == sorted([jessen, gnss, gi])
+    assert [gi, gnss, landsnr, jessen, station, ekstern, diverse, refgeoid] == sorted(
+        [refgeoid, ekstern, station, landsnr, gi, diverse, jessen, gnss]
+    )
+
+    assert gnss > gnss2
+
+
+def test_lighed():
+    gi = lav_ident("IDENT:GI", "G.M.902")
+
+    assert gi == "G.M.902"
+    assert gi == gi
+    assert str(gi) == "G.M.902"
+
+
+def test_ident_type():
+    gi = lav_ident("IDENT:GI", "G.M.902")
+
+    assert gi.variant == "IDENT:GI"
+
+
+def test_instantiering_af_ikke_ident():
+    with pytest.raises(ValueError):
+        lav_ident("ATTR:TEST", "I hvert fald ikke en ident")

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -131,3 +131,11 @@ def test_identer(firedb: FireDb):
     assert "SKEJ" in punkt.identer
     assert "102-08-00802" in punkt.identer
     assert len(punkt.identer) == 2
+
+
+def test_punkt_cache(firedb: FireDb):
+    punkt = firedb.hent_punkt("8e5e57f8-d3c4-45f2-a2a9-492f52d7df1c")
+
+    assert punkt is firedb.hent_punkt("SKEJ")
+    assert punkt is firedb.hent_punkt("102-08-00802")
+    assert punkt is firedb.hent_punkt("8e5e57f8-d3c4-45f2-a2a9-492f52d7df1c")

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -108,7 +108,7 @@ def test_luk_punkt(
         firedb.luk_punkt(999)
 
 
-def test_ident(firedb: FireDb):
+def test_ident(firedb: FireDb, punkt: Punkt):
     """
     Test at Punkt.ident returnerer det forventede ident.
 
@@ -117,6 +117,17 @@ def test_ident(firedb: FireDb):
     skal returneres.
     """
 
+    assert punkt.ident == punkt.id
+
     punkt = firedb.hent_punkt("8e5e57f8-d3c4-45f2-a2a9-492f52d7df1c")
 
     assert punkt.ident == "SKEJ"
+
+
+def test_identer(firedb: FireDb):
+
+    punkt = firedb.hent_punkt("8e5e57f8-d3c4-45f2-a2a9-492f52d7df1c")
+
+    assert "SKEJ" in punkt.identer
+    assert "102-08-00802" in punkt.identer
+    assert len(punkt.identer) == 2

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -139,3 +139,19 @@ def test_punkt_cache(firedb: FireDb):
     assert punkt is firedb.hent_punkt("SKEJ")
     assert punkt is firedb.hent_punkt("102-08-00802")
     assert punkt is firedb.hent_punkt("8e5e57f8-d3c4-45f2-a2a9-492f52d7df1c")
+
+
+def test_hent_punkt_liste(firedb: FireDb):
+    identer = ["RDIO", "RDO1", "SKEJ"]
+    punkter = firedb.hent_punkt_liste(identer)
+
+    for ident, punkt in zip(identer, punkter):
+        assert ident == punkt.ident
+
+    with pytest.raises(ValueError):
+        firedb.hent_punkt_liste(["SKEJ", "RDIO", "ukendt_ident"], ignorer_ukendte=False)
+
+    punkter = firedb.hent_punkt_liste(
+        ["SKEJ", "RDIO", "ukendt_ident"], ignorer_ukendte=True
+    )
+    assert len(punkter) == 2


### PR DESCRIPTION
Med afsæt i https://github.com/Kortforsyningen/FIRE/pull/183#issuecomment-642088266.

Hovedformålet med dette PR er at indføre caching af punkter i `FireDb`, samt at tilføje en funktion der gør det muligt at trække en række punkter ud ved hjælp af en liste af identer. For at kunne håndtere caching ordentligt (et punkt kan identificeres ved mange identer) er der indført bedre mekanismer til at sortere og udtrække identer for et punkt.

Ved review af dette PR bør hver enkelt commit læses for sig. Se commit messages for yderligere kommentarer til koden. Bemærk at `FireDb.hent_punkt_list()` er implementeret så simpelt som muligt. Jeg har ganske kort kigget på hvor lang tid det tager at trække punkterne ud på denne måde og det ser umiddelbart ikke ud til at være den store tidsrøver. Hvis det viser sig at være tilfældet er der flere muligheder for at trække data ud på en mere effektiv måde, dog med yderligere kompleksitet til følge. 