### PR TITLE
Korriger rapporteret sagsstatus for "info sag"

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -537,7 +537,7 @@ def sag(sagsid: str, **kwargs):
         fire.cli.print(f"  Sagsid        : {sag.id}")
         fire.cli.print(f"  Oprettet      : {sag.registreringfra}")
         fire.cli.print(f"  Sagsbehandler : {sag.behandler}")
-        if sag.aktiv == Boolean.TRUE:
+        if sag.aktiv == True:
             status = "Aktiv"
         else:
             status = "Lukket"


### PR DESCRIPTION
"info sag ..." rapporterer at alle sager er lukkede: sag.aktiv=True matcher åbenbart ikke Boolean.TRUE. Jeg forstår ikke hvorfor det er sådan, men når man retter Boolean.TRUE til True bliver rapporteringen korrekt