### PR TITLE
Indfør generel søgning for fire info infotype

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -474,7 +474,6 @@ def infotype(infotype: str, søg: bool, **kwargs):
                     or_(
                         PunktInformationType.name.ilike(f"%{infotype}%"),
                         PunktInformationType.beskrivelse.ilike(f"%{infotype}%"),
-                        PunktInformationType.anvendelse.ilike(f"%{infotype}%"),
                     )
                 )
                 .order_by(PunktInformationType.name)


### PR DESCRIPTION
Indfører option `-s/--søg`, så man kan sige:

```sh
$ fire info infotype -s skruepløk    

"skruepløk" matcher følgende punktinfotyper:    
                                                
AFM:1952   Skruepløk, 1.5 m lang.               
AFM:1953   Skruepløk, 2.0 m lang.               
AFM:1963   Skruepløk,1.5 m lang, med fedtpatron.
AFM:2950   Skruepløk.                           
AFM:2951   Skruepløk, 1.0 m lang.               
```