### PR TITLE
fire info infotype: Undgå bombe ved manglende match

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -510,7 +510,7 @@ def infotype(infotype: str, søg: bool, **kwargs):
         for punktinfotype in punktinfotyper:
             fire.cli.print(punktinfotype.name)
         return
-    
+
     # undgå at max() bomber ved manglende match
     if len(punktinfotyper) == 0:
         fire.cli.print("...")

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -510,6 +510,11 @@ def infotype(infotype: str, søg: bool, **kwargs):
         for punktinfotype in punktinfotyper:
             fire.cli.print(punktinfotype.name)
         return
+    
+    # undgå at max() bomber ved manglende match
+    if len(punktinfotyper) == 0:
+        fire.cli.print("...")
+        return
 
     bredde = max([len(p.name) for p in punktinfotyper]) + 2
     for punktinfotype in punktinfotyper:


### PR DESCRIPTION
En søgning uden resultat vil føre til en nullængdeuddataliste, som får max(...) til at falde død om, da den i så fald ikke har noget fornuftigt at resultere.