### PR TITLE
Hent punkter med jokertegn

### DIFF
--- a/fire/api/_firedb_hent.py
+++ b/fire/api/_firedb_hent.py
@@ -99,6 +99,29 @@ def hent_punkter(self, ident: str) -> List[Punkt]:
     return result
 
 
+def hent_punkter_med_jokertegn(self, ident: str) -> List[Punkt]:
+    """
+    Returnerer alle punkter der 'like'-matcher 'ident'
+
+    Hvis intet punkt findes udsendes en NoResultFound exception.
+    """
+    result = (
+        self.session.query(Punkt)
+        .join(PunktInformation)
+        .join(PunktInformationType)
+        .filter(
+            PunktInformationType.name.startswith("IDENT:"),
+            PunktInformation.tekst.like(ident),
+            Punkt._registreringtil == None,  # NOQA
+        )
+        .all()
+    )
+
+    if not result:
+        raise NoResultFound
+    return result
+
+
 def hent_alle_punkter(self) -> List[Punkt]:
     return self.session.query(Punkt).all()
 

--- a/fire/api/_firedb_hent.py
+++ b/fire/api/_firedb_hent.py
@@ -99,29 +99,6 @@ def hent_punkter(self, ident: str) -> List[Punkt]:
     return result
 
 
-def hent_punkter_med_jokertegn(self, ident: str) -> List[Punkt]:
-    """
-    Returnerer alle punkter der 'like'-matcher 'ident'
-
-    Hvis intet punkt findes udsendes en NoResultFound exception.
-    """
-    result = (
-        self.session.query(Punkt)
-        .join(PunktInformation)
-        .join(PunktInformationType)
-        .filter(
-            PunktInformationType.name.startswith("IDENT:"),
-            PunktInformation.tekst.like(ident),
-            Punkt._registreringtil == None,  # NOQA
-        )
-        .all()
-    )
-
-    if not result:
-        raise NoResultFound
-    return result
-
-
 def hent_alle_punkter(self) -> List[Punkt]:
     return self.session.query(Punkt).all()
 

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -117,7 +117,6 @@ class FireDb(object):
             .all()
         )
 
-
     def soeg_punkter(self, ident: str) -> List[Punkt]:
         """
         Returnerer alle punkter der 'like'-matcher 'ident'
@@ -139,7 +138,6 @@ class FireDb(object):
         if not result:
             raise NoResultFound
         return result
-
 
     def tilknyt_landsnumre(
         self, punkter: List[Punkt], fikspunktstyper: List[FikspunktsType],

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -70,6 +70,7 @@ class FireDb(object):
         hent_punkt,
         hent_punkt_liste,
         hent_punkter,
+        hent_punkter_med_jokertegn,
         hent_geometri_objekt,
         hent_alle_punkter,
         hent_sag,

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -397,10 +397,7 @@ def punkt(
         ident = ident.replace("GM", "G.M.", 1)
 
     try:
-        if "%" in ident:
-            punkter = firedb.soeg_punkter(ident)
-        else:
-            punkter = firedb.hent_punkter(ident)
+        punkter = firedb.hent_punkter(ident)
     except NoResultFound:
         fire.cli.print(f"Fejl: Kunne ikke finde {ident}.", fg="red", err=True)
         sys.exit(1)

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -304,9 +304,16 @@ def punkt_fuld_rapport(
     default=False,
     help="Udskriv også sjældent anvendte elementer",
 )
+@click.option(
+    "-n",
+    "--antal",
+    is_flag=False,
+    default=20,
+    help="Begræns antallet af punkter der udskrives",
+)
 @fire.cli.default_options()
 @click.argument("ident")
-def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
+def punkt(ident: str, obs: str, koord: str, detaljeret: bool, antal: int, **kwargs) -> None:
     """
     Vis al tilgængelig information om et fikspunkt
 
@@ -389,7 +396,7 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
 
     try:
         if "%" in ident:
-            punkter = firedb.hent_punkter_med_jokertegn(ident)
+            punkter = firedb.soeg_punkter(ident)
         else:
             punkter = firedb.hent_punkter(ident)
     except NoResultFound:
@@ -399,8 +406,11 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
     # Succesfuld søgning - vis hvad der blev fundet
     n = len(punkter)
     for i, punkt in enumerate(punkter):
+        if i==antal:
+            break
         punkt_fuld_rapport(punkt, punkt.ident, i + 1, n, obs, koord, detaljeret)
-
+    if (n > antal):
+        fire.cli.print(f"Yderligere {n-antal} punkter fundet. Brug tilvalg '-n {n}' for at vise alle.")
 
 @info.command()
 @click.option(

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -313,7 +313,9 @@ def punkt_fuld_rapport(
 )
 @fire.cli.default_options()
 @click.argument("ident")
-def punkt(ident: str, obs: str, koord: str, detaljeret: bool, antal: int, **kwargs) -> None:
+def punkt(
+    ident: str, obs: str, koord: str, detaljeret: bool, antal: int, **kwargs
+) -> None:
     """
     Vis al tilgængelig information om et fikspunkt
 
@@ -406,11 +408,14 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, antal: int, **kwar
     # Succesfuld søgning - vis hvad der blev fundet
     n = len(punkter)
     for i, punkt in enumerate(punkter):
-        if i==antal:
+        if i == antal:
             break
         punkt_fuld_rapport(punkt, punkt.ident, i + 1, n, obs, koord, detaljeret)
-    if (n > antal):
-        fire.cli.print(f"Yderligere {n-antal} punkter fundet. Brug tilvalg '-n {n}' for at vise alle.")
+    if n > antal:
+        fire.cli.print(
+            f"Yderligere {n-antal} punkter fundet. Brug tilvalg '-n {n}' for at vise alle."
+        )
+
 
 @info.command()
 @click.option(

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -317,6 +317,9 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
     punktummer og manglende foranstillede nuller, i ofte forekommende, let
     genkendelige tilfælde (GNSS-id, GI/GM-numre, lands- og købstadsnumre).
 
+    Hvis der indgår procenttegn i det søgte punktnavn opfattes disse som
+    jokertegn, og søgningen returnerer alle punkter der matcher mønstret.
+
     Punkt-klassen er omfattende og består af følgende elementer:
 
     Punkt = Punkt(\n
@@ -385,7 +388,10 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
         ident = ident.replace("GM", "G.M.", 1)
 
     try:
-        punkter = firedb.hent_punkter(ident)
+        if ('%' in ident):
+            punkter = firedb.hent_punkter_med_jokertegn(ident)
+        else:
+            punkter = firedb.hent_punkter(ident)
     except NoResultFound:
         fire.cli.print(f"Fejl: Kunne ikke finde {ident}.", fg="red", err=True)
         sys.exit(1)

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -388,7 +388,7 @@ def punkt(ident: str, obs: str, koord: str, detaljeret: bool, **kwargs) -> None:
         ident = ident.replace("GM", "G.M.", 1)
 
     try:
-        if ('%' in ident):
+        if "%" in ident:
             punkter = firedb.hent_punkter_med_jokertegn(ident)
         else:
             punkter = firedb.hent_punkter(ident)


### PR DESCRIPTION
Introducerer `soeg_punkter(ident)`, som matcher `ident` med bruge af LIKE, så man kan søge fx alle højdefikspunkter i et opmålingsdistrikt: `hent_punkter_joker("40-12-09%")`.

Funktionaliteten har tidligere været indbygget i `hent_punkter()`, men er åbenbart ikke blevet merget på det tidspunkt. Det er ellers intentionen bag `fire info punkt` at man også skulle kunne anføre jokertegn.