### PR TITLE
fire søg punkt

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -8,6 +8,7 @@ import getpass
 
 from sqlalchemy import create_engine, func, event, and_, inspect
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import text
 
 from fire.api.model import (
@@ -117,7 +118,7 @@ class FireDb(object):
             .all()
         )
 
-    def soeg_punkter(self, ident: str) -> List[Punkt]:
+    def soeg_punkter(self, ident: str, antal: int = None) -> List[Punkt]:
         """
         Returnerer alle punkter der 'like'-matcher 'ident'
 
@@ -129,9 +130,11 @@ class FireDb(object):
             .join(PunktInformationType)
             .filter(
                 PunktInformationType.name.startswith("IDENT:"),
-                PunktInformation.tekst.like(ident),
+                PunktInformation.tekst.ilike(ident),
                 Punkt._registreringtil == None,  # NOQA
             )
+            .order_by(PunktInformation.tekst)
+            .limit(antal)
             .all()
         )
 

--- a/fire/cli/søg/__init__.py
+++ b/fire/cli/søg/__init__.py
@@ -1,0 +1,9 @@
+import click
+
+
+@click.group()
+def søg():
+    pass
+
+
+from .punkt import punkt

--- a/fire/cli/søg/punkt.py
+++ b/fire/cli/søg/punkt.py
@@ -1,0 +1,41 @@
+import re
+
+import click
+
+import fire.cli
+from fire.cli import firedb
+from . import søg
+
+
+@søg.command()
+@click.argument("ident")
+@click.option(
+    "-n",
+    "--antal",
+    default=20,
+    type=int,
+    help="Begræns antallet af fundne søgeresultater",
+)
+def punkt(ident: str, antal: int):
+    """
+    Søg efter et punkt ud fra dets ident
+
+    Søgeudtryk kan præciseres med wildcards givet ved %. Hvis ingen
+    wildcards angives søges automatisk efter "%IDENT%". Der skælnes
+    ikke mellem små og store bogstaver.
+
+    Antallet af søgeresultater begrænses som standard til 20.
+    """
+    if "%" not in ident:
+        ident = f"%{ident}%"
+
+    ident_pattern = ident.replace("%", ".*")
+
+    punkter = firedb.soeg_punkter(ident, antal)
+    for punkt in punkter:
+        for ident in punkt.identer:
+            if re.match(ident_pattern, ident):
+                fire.cli.print(f"{ident:20}", bold=True, fg="green", nl=False)
+            else:
+                fire.cli.print(f"{ident:20}", nl=False)
+        fire.cli.print(nl=True)

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         gama=fire.cli.gama:gama
         mark=fire.cli.mark:mark
         mtl=fire.cli.mtl:mtl
+        søg=fire.cli.søg:søg
     """,
 )

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -1,6 +1,7 @@
 from typing import List
 from itertools import chain
 
+from sqlalchemy.orm.exc import NoResultFound
 import pytest
 
 from fire.api import FireDb
@@ -155,3 +156,16 @@ def test_hent_punkt_liste(firedb: FireDb):
         ["SKEJ", "RDIO", "ukendt_ident"], ignorer_ukendte=True
     )
     assert len(punkter) == 2
+
+
+def test_soeg_punkter(firedb: FireDb):
+    punkter = firedb.soeg_punkter("%rd%")
+
+    for punkt in punkter:
+        assert punkt.ident in ("RDIO", "RDO1")
+
+    kun_et_punkt = firedb.soeg_punkter("K-63-%", antal=1)
+    assert len(kun_et_punkt) == 1
+
+    with pytest.raises(NoResultFound):
+        firedb.soeg_punkter("punkt der ikke findes")


### PR DESCRIPTION
Bygger oven på #211 

Eksempler:
```
(fire-dev) C:\dev\fire>fire søg punkt K-63-0000% -n 5
K-63-00009          43524
K-63-00008          43523
K-63-00007          43522
K-63-00006          43521
K-63-00005          43520

(fire-dev) C:\dev\fire>fire søg punkt G.M.90% -n 5
G.M.908.1           40-12-09057         210017
G.M.908             40-12-09056         210016
G.M.907.1           40-12-09055         210015
G.M.907             40-12-09054         210014
G.M.906.1           40-12-09053         210013

(fire-dev) C:\dev\fire>fire søg punkt %-V.% -n 5
K-75-09393          K-75-V.12           854144
69-01-09095         69-01-V.7           858816
K-31-V.7            861604
94-01-V.2           862449
K-67-09388          K-67-V.9            875823
```

Det fremgår ikke af ovenstående, men matchende identer fremhæves med fed, grøn tekst. En alternativ løsning er at kun det matchende ident skrives ud, måske er det mere anvendeligt?


Husk at reinstallere FIRE for at ændringerne træder i kraft på kommandolinjen. I roden af git repositoriet:

```
pip install -e .
```