### PR TITLE
Introducer indset_flere_observationer

### DIFF
--- a/fire/api/_firedb_indset.py
+++ b/fire/api/_firedb_indset.py
@@ -95,6 +95,44 @@ def indset_flere_punkter(self, sagsevent: Sagsevent, punkter: List[Punkt]) -> No
     self.session.commit()
 
 
+def indset_flere_observationer(
+    self, sagsevent: Sagsevent, observationer: List[Observation]
+) -> None:
+    """Indsæt flere punkter i punkttabellen, alle under samme sagsevent
+
+    Parameters
+    ----------
+    sagsevent: Sagsevent
+        Nyt (endnu ikke persisteret) sagsevent.
+
+        NB: Principielt ligger "indset_flere_observationer" på et højere API-niveau
+        end "indset_observationer", så det bør overvejes at generere sagsevent her.
+        Argumentet vil så skulle ændres til "sagseventtekst: str", og der vil
+        skulle tilføjes et argument "sag: Sag". Alternativt kan sagseventtekst
+        autogenereres her ("oprettelse af observationerne nn, mm, ...")
+
+    observationer: List[Observation]
+        De observationer der skal persisteres under samme sagsevent
+
+    Returns
+    -------
+    None
+
+    """
+    # Check at alle punkter er i orden
+    for obs in observationer:
+        if not self._is_new_object(obs):
+            raise Exception(f"Observation allerede tilføjet databasen: {obs}")
+
+    self._check_and_prepare_sagsevent(sagsevent, EventType.OBSERVATION_INDSAT)
+
+    for obs in observationer:
+        obs.sagsevent = sagsevent
+        self.session.add(obs)
+
+    self.session.commit()
+
+
 def indset_punkt(self, sagsevent: Sagsevent, punkt: Punkt):
     if not self._is_new_object(punkt):
         raise Exception(f"Punkt er allerede tilføjet databasen: {punkt}")

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -94,6 +94,7 @@ class FireDb(object):
         indset_punkt,
         indset_punktinformation,
         indset_punktinformationtype,
+        indset_flere_observationer,
         indset_observation,
         indset_observationstype,
         indset_beregning,

--- a/test/test_observation.py
+++ b/test/test_observation.py
@@ -6,6 +6,7 @@ from fire.api import FireDb
 from fire.api.model import (
     Sag,
     Sagsevent,
+    SagseventInfo,
     Punkt,
     Observation,
     Geometry,
@@ -78,6 +79,38 @@ def test_hent_observationer_naer_geometri(firedb: FireDb):
 
 def test_indset_observation(firedb: FireDb, sag: Sag, punkt: Punkt):
     obstype = firedb.session.query(ObservationsType).first()
+
+    sagsevent = Sagsevent(sag=sag, id=uuid(), eventtype=EventType.OBSERVATION_INDSAT)
+    sagseventtekst = "Ilægning af observation"
+    sagseventinfo = SagseventInfo(beskrivelse=sagseventtekst)
+    sagsevent.sagseventinfos.append(sagseventinfo)
+
+    obs1 = Observation(
+        antal=0,
+        observationstype=obstype,
+        observationstidspunkt=dt.datetime.utcnow(),
+        opstillingspunkt=punkt,
+        value1=0,
+        value2=0,
+        value3=0,
+        value4=0,
+        value5=0,
+        value6=0,
+        value7=0,
+        value8=0,
+    )
+
+    firedb.indset_observation(sagsevent, obs1)
+
+
+def test_indset_flere_observationer(firedb: FireDb, sag: Sag, punkt: Punkt):
+    obstype = firedb.session.query(ObservationsType).first()
+
+    sagsevent = Sagsevent(sag=sag, id=uuid(), eventtype=EventType.OBSERVATION_INDSAT)
+    sagseventtekst = "Ilægning af flere observationer"
+    sagseventinfo = SagseventInfo(beskrivelse=sagseventtekst)
+    sagsevent.sagseventinfos.append(sagseventinfo)
+
     obs1 = Observation(
         antal=0,
         observationstype=obstype,
@@ -107,7 +140,8 @@ def test_indset_observation(firedb: FireDb, sag: Sag, punkt: Punkt):
         value7=0,
         value8=0,
     )
-    firedb.indset_flere_observationer(Sagsevent(sag=sag), [obs1, obs2])
+
+    firedb.indset_flere_observationer(sagsevent, [obs1, obs2])
 
 
 def test_luk_observation(

--- a/test/test_observation.py
+++ b/test/test_observation.py
@@ -78,7 +78,7 @@ def test_hent_observationer_naer_geometri(firedb: FireDb):
 
 def test_indset_observation(firedb: FireDb, sag: Sag, punkt: Punkt):
     obstype = firedb.session.query(ObservationsType).first()
-    observation = Observation(
+    obs1 = Observation(
         antal=0,
         observationstype=obstype,
         observationstidspunkt=dt.datetime.utcnow(),
@@ -92,7 +92,22 @@ def test_indset_observation(firedb: FireDb, sag: Sag, punkt: Punkt):
         value7=0,
         value8=0,
     )
-    firedb.indset_observation(Sagsevent(sag=sag), observation)
+
+    obs2 = Observation(
+        antal=0,
+        observationstype=obstype,
+        observationstidspunkt=dt.datetime.utcnow(),
+        opstillingspunkt=punkt,
+        value1=0,
+        value2=0,
+        value3=0,
+        value4=0,
+        value5=0,
+        value6=0,
+        value7=0,
+        value8=0,
+    )
+    firedb.indset_flere_observationer(Sagsevent(sag=sag), [obs1, obs2])
 
 
 def test_luk_observation(

--- a/test/test_observation.py
+++ b/test/test_observation.py
@@ -13,6 +13,7 @@ from fire.api.model import (
     ObservationsType,
     EventType,
 )
+from fire import uuid
 
 
 def test_observation(firedb: FireDb, observation: Observation):

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -40,6 +40,20 @@ def test_indset_punkt(firedb: FireDb, sag: Sag):
     firedb.indset_punkt(Sagsevent(sag=sag), p)
 
 
+def test_indset_flere_punkter(firedb: FireDb, sag: Sag):
+    p = Punkt()
+    go = GeometriObjekt()
+    go.geometri = Point([1, 1])
+    p.geometriobjekter.append(go)
+
+    q = Punkt()
+    go = GeometriObjekt()
+    go.geometri = Point([2, 2])
+    q.geometriobjekter.append(go)
+
+    firedb.indset_flere_punkter(Sagsevent(sag=sag), [p, q])
+
+
 def test_indset_punkt_with_invalid_sagsevent_eventtype(firedb: FireDb, sag: Sag):
     p = Punkt()
     go = GeometriObjekt()


### PR DESCRIPTION
indset_flere_observationer er den naturlige pendant til
indset_flere_punkter: Den indsætter et antal observationer
under samme sagshændelse.

Indfører desuden den manglende test for indset_flere_punkter
og en tilsvarende for indset_flere_observationer. Disse er
dog skrevet helt i blinde og baseret på de eksisterende tests.