### PR TITLE
Tilføj --debug flag på fire cli kommandoer

### DIFF
--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -15,6 +15,14 @@ def _set_monochrome(ctx, param, value):
     _show_colors = not value
 
 
+def _set_debug(ctx, param, value):
+    """
+    Ændrer debug tilstand på firedb object vha --debug.
+    """
+    global firedb
+    firedb.engine.echo = value
+
+
 _default_options = [
     click.option(
         "-m",
@@ -23,6 +31,7 @@ _default_options = [
         callback=_set_monochrome,
         help="Vis ikke farver i terminalen",
     ),
+    click.option("--debug", is_flag=True, callback=_set_debug, help="Vis debug output"),
     click.help_option(help="Vis denne hjælp tekst"),
 ]
 

--- a/fire/cli/søg/punkt.py
+++ b/fire/cli/søg/punkt.py
@@ -8,6 +8,7 @@ from . import søg
 
 
 @søg.command()
+@fire.cli.default_options()
 @click.argument("ident")
 @click.option(
     "-n",


### PR DESCRIPTION
```
>fire info srid EPSG:4258
--- SRID ---
 Name:       :  EPSG:4258
 Description :  Geografiske koordinater 2D: ETRS89
```

versus

```
>fire info srid --debug EPSG:4258
2020-08-20 14:54:07,728 INFO sqlalchemy.engine.base.Engine SELECT USER FROM DUAL
2020-08-20 14:54:07,729 INFO sqlalchemy.engine.base.Engine {}
2020-08-20 14:54:07,736 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS VARCHAR(60 CHAR)) AS anon_1 FROM DUAL
2020-08-20 14:54:07,737 INFO sqlalchemy.engine.base.Engine {}
2020-08-20 14:54:07,741 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS NVARCHAR2(60)) AS anon_1 FROM DUAL
2020-08-20 14:54:07,742 INFO sqlalchemy.engine.base.Engine {}
2020-08-20 14:54:07,747 INFO sqlalchemy.engine.base.Engine select value from nls_session_parameters where parameter = 'NLS_NUMERIC_CHARACTERS'
2020-08-20 14:54:07,748 INFO sqlalchemy.engine.base.Engine {}
2020-08-20 14:54:07,754 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)
2020-08-20 14:54:07,758 INFO sqlalchemy.engine.base.Engine SELECT sridtype.srid AS sridtype_srid, sridtype.objektid AS sridtype_objektid, sridtype.sridid AS sridtype_sridid, sridtype.beskrivelse AS sridtype_beskrivelse, sridtype.x AS sridtype_x, sridtype.y AS sridtype_y, sridtype.z AS sridtype_z
FROM sridtype
WHERE sridtype.srid = :srid_1
2020-08-20 14:54:07,758 INFO sqlalchemy.engine.base.Engine {'srid_1': 'EPSG:4258'}
--- SRID ---
 Name:       :  EPSG:4258
 Description :  Geografiske koordinater 2D: ETRS89
```