### PR TITLE
Brug servicenavn, frem for databasenavn.

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -427,7 +427,7 @@ class FireDb(object):
         username = self.config.get("connection", "username")
         password = self.config.get("connection", "password")
         hostname = self.config.get("connection", "hostname")
-        database = self.config.get("connection", "database")
+        service = self.config.get("connection", "service")
         port = self.config.get("connection", "port", fallback=1521)
 
-        return f"{username}:{password}@{hostname}:{port}/{database}"
+        return f"{username}:{password}@{hostname}:{port}/?service_name={service}"


### PR DESCRIPTION
Med overgang til ny databasehardware og opdateret Oracleversion
er det ikke længere databasenavnet, der benyttes ved forbindelse
til FIREs tilhørende database.

Syntaksen for forbindelse ved hjælp af servicenavnet frem for
databasenavnet, er kun marginalt anderledes end den tidligere
anvendte, men de to er inkompatible.