### PR TITLE
Brug hellere servicenavn end databasenavn

### DIFF
--- a/.circleci/fire.ini
+++ b/.circleci/fire.ini
@@ -4,6 +4,7 @@ username = fire
 hostname = localhost
 database = xe
 service = fire
+method = database
 
 [test_connection]
 password = fire
@@ -11,6 +12,7 @@ username = fire
 hostname = localhost
 database = xe
 service = fire
+method = database
 
 # GNU GAMA KONFIGURATION
 #

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -431,19 +431,23 @@ class FireDb(object):
         hostname = self.config.get("connection", "hostname")
         database = self.config.get("connection", "database", fallback="")
         service = self.config.get("connection", "service", fallback="")
-        port = self.config.get("connection", "port", fallback=1521)
         method = self.config.get("connection", "method", fallback="service")
+        port = self.config.get("connection", "port", fallback=1521)
 
-        if service==database=="":
-            raise ValueError("fire.ini skal definere mindst en af nøglerne {'database', 'service'}")
         if method not in {"service", "database"}:
-            raise ValueError("fire.ini/method skal være element i {'database', 'service'}")
+            raise ValueError(
+                "fire.ini/method skal være enten 'database' eller 'service'"
+            )
 
-        if method=="service":
-            if  service=="":
-                raise ValueError("fire.ini/service skal defineres når method=='service'")
+        if method == "service":
+            if service == "":
+                raise ValueError(
+                    "fire.ini/service skal defineres når method er 'service'"
+                )
             return f"{username}:{password}@{hostname}:{port}/?service_name={service}"
 
-        if database=="":
-            raise ValueError("fire.ini/database skal defineres når method=='database'")
+        if database == "":
+            raise ValueError(
+                "fire.ini/database skal defineres når method er 'database'"
+            )
         return f"{username}:{password}@{hostname}:{port}/{database}"

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -429,7 +429,21 @@ class FireDb(object):
         username = self.config.get("connection", "username")
         password = self.config.get("connection", "password")
         hostname = self.config.get("connection", "hostname")
-        database = self.config.get("connection", "database")
+        database = self.config.get("connection", "database", fallback="")
+        service = self.config.get("connection", "service", fallback="")
         port = self.config.get("connection", "port", fallback=1521)
+        method = self.config.get("connection", "method", fallback="service")
 
+        if service==database=="":
+            raise ValueError("fire.ini skal definere mindst en af nøglerne {'database', 'service'}")
+        if method not in {"service", "database"}:
+            raise ValueError("fire.ini/method skal være element i {'database', 'service'}")
+
+        if method=="service":
+            if  service=="":
+                raise ValueError("fire.ini/service skal defineres når method=='service'")
+            return f"{username}:{password}@{hostname}:{port}/?service_name={service}"
+
+        if database=="":
+            raise ValueError("fire.ini/database skal defineres når method=='database'")
         return f"{username}:{password}@{hostname}:{port}/{database}"


### PR DESCRIPTION
Med overgang til ny databasehardware og opdateret Oracleversion
er det ikke længere databasenavnet, der benyttes ved forbindelse
til FIREs tilhørende database.

Syntaksen for forbindelse ved hjælp af servicenavnet frem for
databasenavnet, er kun marginalt anderledes end den tidligere
anvendte, men de to er inkompatible. Og da vi stadig skal bruge
databasenavnsyntaksen i CI/test-sammenhæng er det nødvendigt at
indføre en mellemform.

Det er gjort ved at indføre ini-filnøglen "method", som, hvis
den ikke er sat, tildeles værdien "service".

- Hvis "method" (ad eksplicit eller implicit vej) har værdien
  "service" forsøger vi at åbne databasen via servicenavnet.

- Hvis "method" eksplicit er tildelt værdien "database" forsøger
  vi at åbne databasen via databasenavnet

Den her indførte mellemform er, nota bene, IKKE bagudkompatibel,
så der er indført konsekvensrettelser i .circleci/fire.ini

Inkompatibiliteten er indført med overlæg, bl.a. med henblik på
at sikre at "det sædvanlige tilfælde" bliver så enkelt som muligt.