### PR TITLE
Strømlining af databaseilægningsfunktionerne

### DIFF
--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -246,13 +246,14 @@ def find_faneblad(
             sheet_name=faneblad,
             usecols=anvendte(arkdef),
         )
-    except:
+    except Exception as ex:
         if ignore_failure:
             return None
-        fire.cli.print(f"Der er ingen {faneblad} i '{projektnavn}.xlsx'")
+        fire.cli.print(f"Kan ikke læse {faneblad} fra '{projektnavn}.xlsx'")
         fire.cli.print(
             f"- har du glemt at kopiere den fra '{projektnavn}-resultat.xlsx'?"
         )
+        fire.cli.print(f"Anden mulig årsag: {ex}")
         sys.exit(1)
 
 
@@ -355,8 +356,30 @@ def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
         yield feature
 
 
+def bekræft(spørgsmål: str, alvor: bool, test: bool) -> Tuple[bool, bool]:
+    """Sikkerhedsdialog: Undgå uønsket skrivning til databasen"""
+    # Påtving konsistens mellem alvor/test flag
+    if not alvor:
+        test = True
+        fire.cli.print(f"TESTER '{spørgsmål}'", fg="yellow", bold=True)
+        return alvor, test
+    else:
+        test = False
+
+    # Fortrydelse?: returner inkonsistent tilstand, alvor = test = True
+    fire.cli.print(f" BEKRÆFT: {spørgsmål}? ", bg="red", fg="white")
+    if "ja" != input("OK (ja/nej)? "):
+        fire.cli.print(f"DROPPER '{spørgsmål}'")
+        return True, True
+
+    # Bekræftelse
+    fire.cli.print(f"UDFØRER '{spørgsmål}'")
+    return alvor, test
+
+
 from .opret_sag import opret_sag
 from .læs_observationer import læs_observationer
+from .ilæg_observationer import ilæg_observationer
 from .udtræk_revision import udtræk_revision
 from .ilæg_revision import ilæg_revision
 from .regn import regn

--- a/fire/cli/niv/ilæg_revision.py
+++ b/fire/cli/niv/ilæg_revision.py
@@ -7,8 +7,6 @@ import pandas as pd
 import fire.cli
 from fire.cli import firedb
 from fire import uuid
-
-# Typingelementer fra databaseAPIet.
 from fire.api.model import (
     EventType,
     Punkt,
@@ -20,10 +18,10 @@ from fire.api.model import (
     SagseventInfo,
 )
 
-
 from . import (
     ARKDEF_REVISION,
-    anvendte,
+    bekræft,
+    find_faneblad,
     find_sag,
     find_sagsgang,
     niv,
@@ -91,43 +89,16 @@ def ilæg_revision(
     test = True
     alvor = False
 
-    # Påtving konsistens mellem alvor/test flag
-    if alvor:
-        test = False
-        fire.cli.print(
-            " BEKRÆFT: Skriver reviderede punktdata til FIRE-databasen!!! ",
-            bg="red",
-            fg="white",
-        )
-        fire.cli.print(f"Sags/projekt-navn: {projektnavn}  ({sag['uuid']})")
-        fire.cli.print(f"Sagsbehandler:     {sagsbehandler}")
-        if "ja" != input("OK (ja/nej)? "):
-            fire.cli.print("Dropper skrivning til FIRE-databasen")
-            return
+    fire.cli.print(f"Sags/projekt-navn: {projektnavn}  ({sag.id})")
+    fire.cli.print(f"Sagsbehandler:     {sagsbehandler}")
+    alvor, test = bekræft("Skriv punktrevisionsdata til databasen", alvor, test)
+    # Fortrød de?
+    if alvor and test:
+        return
 
-    if test:
-        fire.cli.print(
-            f" TESTER punktrevision for {projektnavn} ", bg="red", fg="white"
-        )
-
-    try:
-        revision = pd.read_excel(
-            f"{projektnavn}-revision.xlsx",
-            sheet_name="Revision",
-            usecols=anvendte(ARKDEF_REVISION),
-        )
-    except Exception as ex:
-        fire.cli.print(
-            f"Kan ikke læse revisionsblad fra '{projektnavn}-revision.xlsx'",
-            fg="yellow",
-            bold=True,
-        )
-        fire.cli.print(f"Mulig årsag: {ex}")
-        sys.exit(1)
+    revision = find_faneblad(f"{projektnavn}-revision", "Revision", ARKDEF_REVISION)
     bemærkning = " ".join(bemærkning)
-
     opdateret = pd.DataFrame(columns=list(ARKDEF_REVISION))
-    print(opdateret)
 
     # Disse navne er lange at sejle rundt med, så vi laver en kort form
     TEKST = PunktInformationTypeAnvendelse.TEKST


### PR DESCRIPTION
#### 1.
Indfør ensartet tilgang til sikkerhedsdialog ("Er du helt sikker på
at du vil skrive til databasen"-agtige spørgsmål) i de 4 database-
ilægningsfunktioner.

Alle funktionerne accepterer nu de to flag '--test' og '--alvor',
hvor '--test' er automatisk forvalgt. Der skrives KUN til databasen
hvis '--alvor' eksplicit er valgt, og kun efter behørig advarende
dialog med fortrydelsesmulighed.

Funktionen 'bekræft()' centraliserer både flaghåndtering og dialog.

#### 2.
Indfør generel brug af funktionen 'find_faneblad()' i stedet for
individuel fuldfed kode alle steder hvor et faneblad skal bruges.

#### 3.
Tilpasset ilæg_nye_koter() til ny arbejdsgang. Den læser nu fra
fanebladet 'Endelig beregning' og skriver til 'Resultat'