### PR TITLE
Tilføj kwargs argument til fire.cli.søg.punkt

### DIFF
--- a/fire/cli/søg/punkt.py
+++ b/fire/cli/søg/punkt.py
@@ -17,7 +17,7 @@ from . import søg
     type=int,
     help="Begræns antallet af fundne søgeresultater",
 )
-def punkt(ident: str, antal: int):
+def punkt(ident: str, antal: int, **kwargs):
     """
     Søg efter et punkt ud fra dets ident
 


### PR DESCRIPTION
Uden kwargs fejler programmet når default parametre tilføjes.