### PR TITLE
Brug databasegenereret tidsstempel ved lukning af fikspunktregisterobjekt

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -302,7 +302,7 @@ class FireDb(object):
     def _luk_fikspunkregisterobjekt(
         self, objekt: FikspunktregisterObjekt, sagsevent: Sagsevent, commit: bool = True
     ):
-        objekt._registreringtil = datetime.now(tz=timezone.utc)
+        objekt._registreringtil = func.sysdate()
         objekt.sagseventtilid = sagsevent.id
 
         self.session.add(objekt)


### PR DESCRIPTION
Den tidligere anvendelse af datetime.now... gav to timers fejlstempling i databaseregistreringen af slukkede objekter, i forhold til samtidigt indførte nyoprettede og rettede.