### PR TITLE
Ident opslag

### DIFF
--- a/fire/api/_firedb_hent.py
+++ b/fire/api/_firedb_hent.py
@@ -85,8 +85,8 @@ def hent_punkter(self, ident: str) -> List[Punkt]:
                 PunktInformationType.name.startswith("IDENT:"),
                 or_(
                     PunktInformation.tekst == ident,
-                    PunktInformation.tekst.like(f"FO  %{ident}"),
-                    PunktInformation.tekst.like(f"GL  %{ident}"),
+                    PunktInformation.tekst == f"FO  {ident}",
+                    PunktInformation.tekst == f"GL  {ident}",
                 ),
                 Punkt._registreringtil == None,  # NOQA
             )

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -1,8 +1,6 @@
 import datetime
 import itertools
 import textwrap
-import math
-import re
 import sys
 from typing import List
 
@@ -14,6 +12,7 @@ from pyproj.exceptions import CRSError
 
 import fire.cli
 from fire.cli import firedb
+from fire.cli.utils import klargør_ident_til_søgning
 from fire.api.model import (
     Punkt,
     PunktInformation,
@@ -381,39 +380,7 @@ def punkt(
     nivellementsobservationer.
     """
 
-    ident = ident.strip()
-
-    # Vær mindre pedantisk mht. foranstillede nuller hvis identen er et landsnummer
-    landsnummermønster = re.compile("^[0-9]*-[0-9]*-[0-9]*$")
-    if landsnummermønster.match(ident):
-        dele = ident.split("-")
-        herred = int(dele[0])
-        sogn = int(dele[1])
-        lbnr = int(dele[2])
-        ident = f"{herred}-{sogn:02}-{lbnr:05}"
-
-    # Næsten samme procedure for købstadsnumre
-    købstadsnummermønster = re.compile("^[Kk][ ]*-[0-9]*-[0-9]*$")
-    if købstadsnummermønster.match(ident):
-        dele = ident.split("-")
-        stad = int(dele[1])
-        lbnr = int(dele[2])
-        ident = f"K-{stad:02}-{lbnr:05}"
-
-    # GNSS-id'er er indeholder pr. def. kun A-Z0-9, så her kan vi også lette lidt på stringensen
-    gnssid = re.compile("^[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]$")
-    if gnssid.match(ident):
-        ident = str(ident).upper()
-
-    # Og nogle hjørneafskæringer for hyppigt brugte navne
-    if ident.startswith("gi"):
-        ident = ident.replace("gi", "G.I.", 1)
-    if ident.startswith("GI"):
-        ident = ident.replace("GI", "G.I.", 1)
-    if ident.startswith("gm"):
-        ident = ident.replace("gm", "G.M.", 1)
-    if ident.startswith("GM"):
-        ident = ident.replace("GM", "G.M.", 1)
+    ident = klargør_ident_til_søgning(ident)
 
     try:
         punkter = firedb.hent_punkter(ident)

--- a/fire/cli/søg/punkt.py
+++ b/fire/cli/søg/punkt.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
 from fire.cli import firedb
+from fire.cli.utils import klargør_ident_til_søgning
 from . import søg
 
 
@@ -29,6 +30,7 @@ def punkt(ident: str, antal: int, **kwargs):
 
     Antallet af søgeresultater begrænses som standard til 20.
     """
+    ident = klargør_ident_til_søgning(ident)
     if "%" not in ident:
         ident = f"%{ident}%"
 

--- a/fire/cli/utils.py
+++ b/fire/cli/utils.py
@@ -1,6 +1,7 @@
 """
 Diverse redskaber til brug i fire.cli.
 """
+import re
 
 import click
 from datetime import datetime
@@ -39,3 +40,45 @@ class Datetime(click.ParamType):
                 param,
                 ctx,
             )
+
+
+def klargør_ident_til_søgning(ident: str) -> str:
+    """
+    Oversættelse af almindelige "fejl"-stavelser af identer, fx gi istedet for G.I.,
+    forud for søgning efter punkter.
+    """
+    ident = ident.strip()
+
+    # Vær mindre pedantisk mht. foranstillede nuller hvis identen er et landsnummer
+    landsnummermønster = re.compile("^[0-9]*-[0-9]*-[0-9]*$")
+    if landsnummermønster.match(ident):
+        dele = ident.split("-")
+        herred = int(dele[0])
+        sogn = int(dele[1])
+        lbnr = int(dele[2])
+        ident = f"{herred}-{sogn:02}-{lbnr:05}"
+
+    # Næsten samme procedure for købstadsnumre
+    købstadsnummermønster = re.compile("^[Kk][ ]*-[0-9]*-[0-9]*$")
+    if købstadsnummermønster.match(ident):
+        dele = ident.split("-")
+        stad = int(dele[1])
+        lbnr = int(dele[2])
+        ident = f"K-{stad:02}-{lbnr:05}"
+
+    # GNSS-id'er er indeholder pr. def. kun A-Z0-9, så her kan vi også lette lidt på stringensen
+    gnssid = re.compile("^[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]$")
+    if gnssid.match(ident):
+        ident = str(ident).upper()
+
+    # Og nogle hjørneafskæringer for hyppigt brugte navne
+    if ident.startswith("gi"):
+        ident = ident.replace("gi", "G.I.", 1)
+    if ident.startswith("GI"):
+        ident = ident.replace("GI", "G.I.", 1)
+    if ident.startswith("gm"):
+        ident = ident.replace("gm", "G.M.", 1)
+    if ident.startswith("GM"):
+        ident = ident.replace("GM", "G.M.", 1)
+
+    return ident


### PR DESCRIPTION
Indfører samme identopslagslogik i `fire søg punkt` som findes i `fire info punkt`. Derudover fjernes muligheden for søgning med wildcards på punkter i nordatlanten fra `fire info punkt`, da det er logik der ikke længere er aktuel og skulle være fjernet i et tidligere commit.

Closes #238
Closes #242