### PR TITLE
DDL oprydning

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -66,7 +66,7 @@ class FireDb(object):
         def listener(thissession, flush_context, instances):
             for obj in thissession.deleted:
                 if isinstance(obj, RegisteringTidObjekt):
-                    obj._registreringtil = func.sysdate()
+                    obj._registreringtil = func.current_timestamp()
                     thissession.add(obj)
 
     from ._firedb_hent import (
@@ -360,7 +360,7 @@ class FireDb(object):
     def _luk_fikspunkregisterobjekt(
         self, objekt: FikspunktregisterObjekt, sagsevent: Sagsevent, commit: bool = True
     ):
-        objekt._registreringtil = func.sysdate()
+        objekt._registreringtil = func.current_timestamp()
         objekt.sagseventtilid = sagsevent.id
 
         self.session.add(objekt)

--- a/fire/api/model/__init__.py
+++ b/fire/api/model/__init__.py
@@ -2,6 +2,7 @@
 """
 import sqlalchemy.ext.declarative
 from sqlalchemy import Column, Integer, DateTime, String, func
+from sqlalchemy.dialects.oracle import TIMESTAMP
 
 
 class BetterBehavedEnum(sqlalchemy.types.TypeDecorator):
@@ -66,9 +67,9 @@ class RegisteringFraObjekt(DeclarativeBase):
     objektid = Column(Integer, primary_key=True)
     _registreringfra = Column(
         "registreringfra",
-        DateTime(timezone=True),
+        TIMESTAMP(timezone=True),
         nullable=False,
-        default=func.sysdate(),
+        default=func.current_timestamp(),
     )
 
     @property
@@ -83,9 +84,9 @@ class RegisteringTidObjekt(DeclarativeBase):
     objektid = Column(Integer, primary_key=True)
     _registreringfra = Column(
         "registreringfra",
-        DateTime(timezone=True),
+        TIMESTAMP(timezone=True),
         nullable=False,
-        default=func.sysdate(),
+        default=func.current_timestamp(),
     )
     _registreringtil = Column("registreringtil", DateTime(timezone=True))
 

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -8,12 +8,12 @@ from sqlalchemy import (
     String,
     Integer,
     Float,
-    DateTime,
     ForeignKey,
     Enum,
     func,
 )
 from sqlalchemy.orm import relationship, reconstructor
+from sqlalchemy.dialects.oracle import TIMESTAMP
 
 import fire
 from fire.api.model import (
@@ -309,7 +309,7 @@ class Koordinat(FikspunktregisterObjekt):
     sx = Column(Float)
     sy = Column(Float)
     sz = Column(Float)
-    t = Column(DateTime(timezone=True), default=func.sysdate())
+    t = Column(TIMESTAMP(timezone=True), default=func.current_timestamp())
     transformeret = Column(StringEnum(Boolean), nullable=False, default=Boolean.FALSE)
     _fejlmeldt = Column(
         "fejlmeldt", StringEnum(Boolean), nullable=False, default=Boolean.FALSE
@@ -446,7 +446,7 @@ class Observation(FikspunktregisterObjekt):
         foreign_keys=[sagseventtilid],
         back_populates="observationer_slettede",
     )
-    observationstidspunkt = Column(DateTime(timezone=True), nullable=False)
+    observationstidspunkt = Column(TIMESTAMP(timezone=True), nullable=False)
     antal = Column(Integer, nullable=False, default=1)
     gruppe = Column(Integer)
     observationstypeid = Column(

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -512,8 +512,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -525,8 +525,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -538,8 +538,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -551,8 +551,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -564,8 +564,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -577,8 +577,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -590,8 +590,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;
@@ -603,8 +603,8 @@ ADD
     nvl(
       registreringtil,
       to_timestamp_tz(
-        '31/12/2099 00:00:00.000000 +1:00',
-        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+        '2099-12-31T00:00.0000000+01:00',
+        'YYYY-MM-DD"t"HH24:MI:SS.FF7TZR'
       )
     ) >= registreringfra
   ) ENABLE VALIDATE;

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -2,452 +2,612 @@
 --                                TABLE CREATION
 -----------------------------------------------------------------------------------------
 
-CREATE TABLE BEREGNING (
-  OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (
+CREATE TABLE beregning (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
     START WITH
       1 INCREMENT BY 1 ORDER NOCACHE
   ) PRIMARY KEY,
-  REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-  REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-  SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-  SAGSEVENTTILID VARCHAR2(36)
-);
-
-CREATE TABLE BEREGNING_KOORDINAT (
-
-   BEREGNINGOBJEKTID INTEGER NOT NULL,
-   KOORDINATOBJEKTID INTEGER NOT NULL,
-   PRIMARY KEY (BEREGNINGOBJEKTID, KOORDINATOBJEKTID)
-);
-
-CREATE TABLE BEREGNING_OBSERVATION (
-
-   BEREGNINGOBJEKTID INTEGER NOT NULL,
-   OBSERVATIONOBJEKTID INTEGER NOT NULL,
-   PRIMARY KEY (BEREGNINGOBJEKTID, OBSERVATIONOBJEKTID)
-);
-
-CREATE TABLE EVENTTYPE (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL,
-   EVENT VARCHAR2(4000) NOT NULL,
-   EVENTTYPEID INTEGER NOT NULL
-);
-
-CREATE TABLE GEOMETRIOBJEKT (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-   SAGSEVENTTILID VARCHAR2(36),
-   GEOMETRI SDO_GEOMETRY NOT NULL,
-   PUNKTID VARCHAR2(36) NOT NULL
-);
-INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) VALUES ('GEOMETRIOBJEKT', 'GEOMETRI', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005), MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)), 4326);
-
-CREATE TABLE HERREDSOGN (
-  OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-  KODE VARCHAR2(6) NOT NULL,
-  GEOMETRI SDO_GEOMETRY NOT NULL
-);
-INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) VALUES ('HERREDSOGN', 'GEOMETRI', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005), MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)), 4326);
-
-
-CREATE TABLE KOORDINAT (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-   SAGSEVENTTILID VARCHAR2(36),
-   SRIDID INTEGER NOT NULL,
-   SX NUMBER,
-   SY NUMBER,
-   SZ NUMBER,
-   T TIMESTAMP WITH TIME ZONE NOT NULL,
-   FEJLMELDT VARCHAR2(5) NOT NULL,
-   TRANSFORMERET VARCHAR2(5) NOT NULL,
-   ARTSKODE INTEGER,
-   X NUMBER,
-   Y NUMBER,
-   Z NUMBER,
-   PUNKTID VARCHAR2(36) NOT NULL
-);
-
-CREATE TABLE KONFIGURATION (
-  OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-  DIR_SKITSER VARCHAR(200) NOT NULL,
-  DIR_MATERIALE VARCHAR(200) NOT NULL
-);
--- Index sikrer at der kun kan indsættes een række i tabellen
-CREATE UNIQUE INDEX only_one_row ON konfiguration ('1');
-
-CREATE TABLE OBSERVATION (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   ID VARCHAR2(36) NOT NULL,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   VALUE1 NUMBER,
-   VALUE2 NUMBER,
-   VALUE3 NUMBER,
-   VALUE4 NUMBER,
-   VALUE5 NUMBER,
-   VALUE6 NUMBER,
-   VALUE7 NUMBER,
-   VALUE8 NUMBER,
-   VALUE9 NUMBER,
-   VALUE10 NUMBER,
-   VALUE11 NUMBER,
-   VALUE12 NUMBER,
-   VALUE13 NUMBER,
-   VALUE14 NUMBER,
-   VALUE15 NUMBER,
-   SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-   SAGSEVENTTILID VARCHAR2(36),
-   OBSERVATIONSTYPEID INTEGER NOT NULL,
-   ANTAL INTEGER NOT NULL,
-   GRUPPE INTEGER,
-   OBSERVATIONSTIDSPUNKT TIMESTAMP WITH TIME ZONE NOT NULL,
-   OPSTILLINGSPUNKTID VARCHAR2(36) NOT NULL,
-   SIGTEPUNKTID VARCHAR2(36)
-);
-
-CREATE TABLE OBSERVATIONSTYPE (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   OBSERVATIONSTYPEID INTEGER NOT NULL,
-   OBSERVATIONSTYPE VARCHAR2(4000) NOT NULL,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL,
-   SIGTEPUNKT VARCHAR2(5) NOT NULL,
-   VALUE1 VARCHAR2(4000),
-   VALUE2 VARCHAR2(4000),
-   VALUE3 VARCHAR2(4000),
-   VALUE4 VARCHAR2(4000),
-   VALUE5 VARCHAR2(4000),
-   VALUE6 VARCHAR2(4000),
-   VALUE7 VARCHAR2(4000),
-   VALUE8 VARCHAR2(4000),
-   VALUE9 VARCHAR2(4000),
-   VALUE10 VARCHAR2(4000),
-   VALUE11 VARCHAR2(4000),
-   VALUE12 VARCHAR2(4000),
-   VALUE13 VARCHAR2(4000),
-   VALUE14 VARCHAR2(4000),
-   VALUE15 VARCHAR2(4000)
-);
-
-CREATE TABLE PUNKT (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-   SAGSEVENTTILID VARCHAR2(36),
-   ID VARCHAR2(36) NOT NULL
-);
-
-CREATE TABLE PUNKTINFO (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-   SAGSEVENTTILID VARCHAR2(36),
-   INFOTYPEID INTEGER NOT NULL,
-   TAL NUMBER,
-   TEKST VARCHAR2(4000),
-   PUNKTID VARCHAR2(36) NOT NULL
-);
-
-CREATE TABLE PUNKTINFOTYPE (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   INFOTYPEID INTEGER NOT NULL,
-   INFOTYPE VARCHAR2(4000) NOT NULL,
-   ANVENDELSE VARCHAR2(9) NOT NULL,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  sagseventfraid VARCHAR2(36) NOT NULL,
+  sagseventtilid VARCHAR2(36)
 );
 
 
-CREATE TABLE SAG (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   ID VARCHAR2(36) NOT NULL,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL
+CREATE TABLE beregning_koordinat (
+  beregningobjektid INTEGER NOT NULL,
+  koordinatobjektid INTEGER NOT NULL,
+  PRIMARY KEY (beregningobjektid, koordinatobjektid)
 );
 
-CREATE TABLE SAGSEVENT (
 
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   ID VARCHAR2(36) NOT NULL,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   EVENTTYPEID INTEGER NOT NULL,
-   SAGSID VARCHAR2(36) NOT NULL
+CREATE TABLE beregning_observation (
+  beregningobjektid INTEGER NOT NULL,
+  observationobjektid INTEGER NOT NULL,
+  PRIMARY KEY (beregningobjektid, observationobjektid)
 );
 
-CREATE TABLE SAGSEVENTINFO (
 
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   BESKRIVELSE VARCHAR2(4000),
-   SAGSEVENTID VARCHAR2(36) NOT NULL
+CREATE TABLE eventtype (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  beskrivelse VARCHAR2(4000) NOT NULL,
+  event VARCHAR2(4000) NOT NULL,
+  eventtypeid INTEGER NOT NULL
 );
 
-CREATE TABLE SAGSEVENTINFO_HTML (
 
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   HTML CLOB NOT NULL,
-   SAGSEVENTINFOOBJEKTID INTEGER NOT NULL
+CREATE TABLE geometriobjekt (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  sagseventfraid VARCHAR2(36) NOT NULL,
+  sagseventtilid VARCHAR2(36),
+  geometri SDO_GEOMETRY NOT NULL,
+  punktid VARCHAR2(36) NOT NULL
 );
+
+INSERT INTO
+  user_sdo_geom_metadata (table_name, column_name, diminfo, srid)
+VALUES
+  (
+    'GEOMETRIOBJEKT',
+    'GEOMETRI',
+    MDSYS.SDO_DIM_ARRAY(
+      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+    ),
+    4326
+  );
+
+
+CREATE TABLE herredsogn (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  kode VARCHAR2(6) NOT NULL,
+  geometri SDO_GEOMETRY NOT NULL
+);
+
+INSERT INTO
+  user_sdo_geom_metadata (table_name, column_name, diminfo, srid)
+VALUES
+  (
+    'HERREDSOGN',
+    'GEOMETRI',
+    MDSYS.SDO_DIM_ARRAY(
+      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+    ),
+    4326
+  );
+
+CREATE TABLE koordinat (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  sagseventfraid VARCHAR2(36) NOT NULL,
+  sagseventtilid VARCHAR2(36),
+  sridid INTEGER NOT NULL,
+  sx NUMBER,
+  sy NUMBER,
+  sz NUMBER,
+  t TIMESTAMP WITH TIME ZONE NOT NULL,
+  fejlmeldt VARCHAR2(5) NOT NULL,
+  transformeret VARCHAR2(5) NOT NULL,
+  artskode INTEGER,
+  x NUMBER,
+  y NUMBER,
+  z NUMBER,
+  punktid VARCHAR2(36) NOT NULL
+);
+
+
+CREATE TABLE konfiguration (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  dir_skitser VARCHAR(200) NOT NULL,
+  dir_materiale VARCHAR(200) NOT NULL
+);
+
+
+CREATE TABLE observation (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  id VARCHAR2(36) NOT NULL,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  value1 NUMBER,
+  value2 NUMBER,
+  value3 NUMBER,
+  value4 NUMBER,
+  value5 NUMBER,
+  value6 NUMBER,
+  value7 NUMBER,
+  value8 NUMBER,
+  value9 NUMBER,
+  value10 NUMBER,
+  value11 NUMBER,
+  value12 NUMBER,
+  value13 NUMBER,
+  value14 NUMBER,
+  value15 NUMBER,
+  sagseventfraid VARCHAR2(36) NOT NULL,
+  sagseventtilid VARCHAR2(36),
+  observationstypeid INTEGER NOT NULL,
+  antal INTEGER NOT NULL,
+  gruppe INTEGER,
+  observationstidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
+  opstillingspunktid VARCHAR2(36) NOT NULL,
+  sigtepunktid VARCHAR2(36)
+);
+
+
+CREATE TABLE observationstype (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  observationstypeid INTEGER NOT NULL,
+  observationstype VARCHAR2(4000) NOT NULL,
+  beskrivelse VARCHAR2(4000) NOT NULL,
+  sigtepunkt VARCHAR2(5) NOT NULL,
+  value1 VARCHAR2(4000),
+  value2 VARCHAR2(4000),
+  value3 VARCHAR2(4000),
+  value4 VARCHAR2(4000),
+  value5 VARCHAR2(4000),
+  value6 VARCHAR2(4000),
+  value7 VARCHAR2(4000),
+  value8 VARCHAR2(4000),
+  value9 VARCHAR2(4000),
+  value10 VARCHAR2(4000),
+  value11 VARCHAR2(4000),
+  value12 VARCHAR2(4000),
+  value13 VARCHAR2(4000),
+  value14 VARCHAR2(4000),
+  value15 VARCHAR2(4000)
+);
+
+
+CREATE TABLE punkt (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  sagseventfraid VARCHAR2(36) NOT NULL,
+  sagseventtilid VARCHAR2(36),
+  id VARCHAR2(36) NOT NULL
+);
+
+
+CREATE TABLE punktinfo (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  sagseventfraid VARCHAR2(36) NOT NULL,
+  sagseventtilid VARCHAR2(36),
+  infotypeid INTEGER NOT NULL,
+  tal NUMBER,
+  tekst VARCHAR2(4000),
+  punktid VARCHAR2(36) NOT NULL
+);
+
+
+CREATE TABLE punktinfotype (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  infotypeid INTEGER NOT NULL,
+  infotype VARCHAR2(4000) NOT NULL,
+  anvendelse VARCHAR2(9) NOT NULL,
+  beskrivelse VARCHAR2(4000) NOT NULL
+);
+
+
+CREATE TABLE sag (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  id VARCHAR2(36) NOT NULL,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+
+CREATE TABLE sagsevent (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  id VARCHAR2(36) NOT NULL,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  eventtypeid INTEGER NOT NULL,
+  sagsid VARCHAR2(36) NOT NULL
+);
+
+
+CREATE TABLE sagseventinfo (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  beskrivelse VARCHAR2(4000),
+  sagseventid VARCHAR2(36) NOT NULL
+);
+
+
+CREATE TABLE sagseventinfo_html (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  html CLOB NOT NULL,
+  sagseventinfoobjektid INTEGER NOT NULL
+);
+
 
 CREATE TABLE SAGSEVENTINFO_MATERIALE (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   MD5SUM VARCHAR2(32) NOT NULL,
-   STI VARCHAR2(4000) NOT NULL,
-   SAGSEVENTINFOOBJEKTID INTEGER NOT NULL
-);
-
-CREATE TABLE SAGSINFO (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   AKTIV VARCHAR2(5) NOT NULL,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   JOURNALNUMMER VARCHAR2(4000),
-   BEHANDLER VARCHAR2(4000) NOT NULL,
-   BESKRIVELSE VARCHAR2(4000),
-   SAGSID VARCHAR2(36) NOT NULL
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  md5sum VARCHAR2(32) NOT NULL,
+  sti VARCHAR2(4000) NOT NULL,
+  sagseventinfoobjektid INTEGER NOT NULL
 );
 
 
-CREATE TABLE SRIDTYPE (
-
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   X VARCHAR2(4000),
-   Y VARCHAR2(4000),
-   Z VARCHAR2(4000),
-   SRIDID INTEGER NOT NULL,
-   SRID VARCHAR2(36) NOT NULL,
-   BESKRIVELSE VARCHAR2(4000) NOT NULL
+CREATE TABLE sagsinfo (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  aktiv VARCHAR2(5) NOT NULL,
+  registreringfra TIMESTAMP WITH TIME ZONE NOT NULL,
+  registreringtil TIMESTAMP WITH TIME ZONE,
+  journalnummer VARCHAR2(4000),
+  behandler VARCHAR2(4000) NOT NULL,
+  beskrivelse VARCHAR2(4000),
+  sagsid VARCHAR2(36) NOT NULL
 );
+
+
+CREATE TABLE sridtype (
+  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  x VARCHAR2(4000),
+  y VARCHAR2(4000),
+  z VARCHAR2(4000),
+  sridid INTEGER NOT NULL,
+  srid VARCHAR2(36) NOT NULL,
+  beskrivelse VARCHAR2(4000) NOT NULL
+);
+
 
 -----------------------------------------------------------------------------------------
 --                                  CONSTRAINTS & INDEX
 -----------------------------------------------------------------------------------------
 
+-- Check constraints på
+ALTER TABLE
+  koordinat
+ADD
+  CONSTRAINT ck_koordinat_transformer248 CHECK (transformeret IN ('true', 'false'));
 
-ALTER TABLE KOORDINAT ADD CONSTRAINT CK_KOORDINAT_TRANSFORMER248 CHECK (TRANSFORMERET IN ('true', 'false'));
-ALTER TABLE KOORDINAT ADD CONSTRAINT CK_KOORDINAT_FEJLMELDT CHECK (FEJLMELDT IN ('true', 'false'));
-ALTER TABLE OBSERVATIONSTYPE ADD CONSTRAINT CK_OBSERVATION_SIGTEPUNKT085 CHECK (SIGTEPUNKT IN ('true', 'false'));
-ALTER TABLE PUNKTINFOTYPE ADD CONSTRAINT CK_PUNKTINFOTY_ANVENDELSE138 CHECK (ANVENDELSE IN ('FLAG', 'TAL', 'TEKST'));
-ALTER TABLE SAGSINFO ADD CONSTRAINT CK_SAGSINFO_AKTIV060 CHECK (AKTIV IN ('true', 'false'));
+ALTER TABLE
+  koordinat
+ADD
+  CONSTRAINT ck_koordinat_fejlmeldt CHECK (fejlmeldt IN ('true', 'false'));
+
+ALTER TABLE
+  observationstype
+ADD
+  CONSTRAINT ck_observation_sigtepunkt085 CHECK (sigtepunkt IN ('true', 'false'));
+
+ALTER TABLE
+  punktinfotype
+ADD
+  CONSTRAINT ck_punktinfoty_anvendelse138 CHECK (anvendelse IN ('FLAG', 'TAL', 'TEKST'));
+
+ALTER TABLE
+  sagsinfo
+ADD
+  CONSTRAINT ck_sagsinfo_aktiv060 CHECK (aktiv IN ('true', 'false'));
+
+-- Constraints der sikrer at namespacedelen er korrekt i PUNKTINFOTYPE
+ALTER TABLE
+  punktinfotype
+ADD
+  CONSTRAINT punktinfotype_con_0001 CHECK (
+    substr(infotype, 1, instr(infotype, ':') -1) IN ('AFM', 'ATTR', 'IDENT', 'NET', 'REGION', 'SKITSE')
+  ) ENABLE VALIDATE;
+
+-- Constraints der sikrer at namespacedelen er korrekt i SRIDTYPE
+ALTER TABLE
+  sridtype
+ADD
+  CONSTRAINT ot_srid_0001 CHECK (
+    substr(SRID, 1, instr(SRID, ':') -1) IN ('DK', 'EPSG', 'GL', 'TS')
+  ) ENABLE VALIDATE;
 
 
-
-CREATE INDEX IDX_GEOMETRIOBJEKT_GEOMETRI ON GEOMETRIOBJEKT (GEOMETRI) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS('layer_gtype=point');
-CREATE INDEX IDX_HERREDSOGN_GEOMETRI ON HERREDSOGN (GEOMETRI) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS ('layer_gtype=polygon');
-
-
--- Constraint der tjekker at PUNKTID eksisterer i PUNKT tabellen inden en række
--- sættes ind i KOORDINAT-, OBSERVATION- og PUNKTINFO-tabellen
-CREATE UNIQUE INDEX ID_IDX_0001 ON PUNKT (ID);
-
-ALTER TABLE PUNKT ADD (
-CONSTRAINT PUNKT_R01
-UNIQUE (ID)
-USING INDEX ID_IDX_0001
-ENABLE VALIDATE);
-
-CREATE UNIQUE INDEX ID_IDX_0002 ON OBSERVATION (ID);
-
-ALTER TABLE OBSERVATION ADD (
-  CONSTRAINT OBSERVATION_R02
-  UNIQUE (ID)
-  USING INDEX ID_IDX_0002
-  ENABLE VALIDATE
-);
-
-CREATE UNIQUE INDEX SRIDTYPE_U01 ON SRIDTYPE (SRIDID);
-
-ALTER TABLE SRIDTYPE ADD
-CONSTRAINT SRIDTYPE_U01
-UNIQUE (SRIDID)
-USING INDEX SRIDTYPE_U01
-ENABLE VALIDATE;
-
-CREATE UNIQUE INDEX EVENTTYPE_U01 ON EVENTTYPE (EVENTTYPEID);
-
-ALTER TABLE EVENTTYPE ADD
-CONSTRAINT EVENTTYPE_U01
-UNIQUE (EVENTTYPEID)
-USING INDEX EVENTTYPE_U01
-ENABLE VALIDATE;
+-- Index sikrer at der kun kan indsættes een række i tabellen
+CREATE UNIQUE INDEX only_one_row ON konfiguration ('1');
 
 -- Index der skal sikre at der til samme punkt ikke tilføjes en koordinat
 -- med samme SRIDID, hvis denne ikke er afregistreret
-CREATE UNIQUE INDEX KOOR_UNIQ_001 ON KOORDINAT (SRIDID, PUNKTID, REGISTRERINGTIL);
+CREATE UNIQUE INDEX koor_uniq_001 ON koordinat (sridid, punktid, registreringtil);
+
+-- Spatiale index
+CREATE INDEX idx_geometriobjekt_geometri ON geometriobjekt (geometri) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS('layer_gtype=point');
+CREATE INDEX idx_herredsogn_geometri ON herredsogn (geometri) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS ('layer_gtype=polygon');
 
 
-CREATE UNIQUE INDEX PUNKTINFOTYPE_IDX_01 ON PUNKTINFOTYPE (INFOTYPEID);
+-- Unique index på alle kolonner med ID'er.
+CREATE UNIQUE INDEX id_idx_0001 ON punkt (id);
 
-ALTER TABLE PUNKTINFOTYPE ADD
-CONSTRAINT PUNKTINFOTYPE_U01
-UNIQUE (INFOTYPEID)
-USING INDEX PUNKTINFOTYPE_IDX_01
-ENABLE VALIDATE;
+ALTER TABLE
+  punkt
+ADD
+  (
+    CONSTRAINT punkt_r01 UNIQUE (id) USING INDEX id_idx_0001 ENABLE VALIDATE
+  );
+
+CREATE UNIQUE INDEX id_idx_0002 ON observation (id);
+
+ALTER TABLE
+  observation
+ADD
+  (
+    CONSTRAINT observation_r02 UNIQUE (id) USING INDEX id_idx_0002 ENABLE VALIDATE
+  );
+
+CREATE UNIQUE INDEX sridtype_u01 ON sridtype (sridid);
+
+ALTER TABLE
+  sridtype
+ADD
+  CONSTRAINT sridtype_u01 UNIQUE (sridid) USING INDEX sridtype_u01 ENABLE VALIDATE;
+
+CREATE UNIQUE INDEX eventtype_u01 ON eventtype (eventtypeid);
+
+ALTER TABLE
+  eventtype
+ADD
+  CONSTRAINT eventtype_u01 UNIQUE (eventtypeid) USING INDEX eventtype_u01 ENABLE VALIDATE;
+
+CREATE UNIQUE INDEX punktinfotype_idx_01 ON punktinfotype (infotypeid);
+
+ALTER TABLE
+  punktinfotype
+ADD
+  CONSTRAINT punktinfotype_u01 UNIQUE (infotypeid) USING INDEX punktinfotype_idx_01 ENABLE VALIDATE;
+
+CREATE UNIQUE INDEX observationstype_idx_001 ON observationstype (observationstypeid);
+
+ALTER TABLE
+  observationstype
+ADD
+  CONSTRAINT observationstype_u01 UNIQUE (observationstypeid) USING INDEX observationstype_idx_001 ENABLE VALIDATE;
+
+ALTER TABLE
+  sag
+ADD
+  CONSTRAINT sag_u01 UNIQUE (id) ENABLE VALIDATE;
+
+ALTER TABLE
+  sagsevent
+ADD
+  CONSTRAINT sagsevent_u01 UNIQUE (id) ENABLE VALIDATE;
 
 
-CREATE UNIQUE INDEX OBSERVATIONSTYPE_IDX_001 ON OBSERVATIONSTYPE
-(OBSERVATIONSTYPEID);
+-- Foreign keys til punktid, sridid og infotypeid, der sikrer at der ikke
+-- indsættes rækker med henvisninger til objekter der ikke findes
+ALTER TABLE
+  koordinat
+ADD
+  CONSTRAINT koordinat_r01 FOREIGN KEY (sridid) REFERENCES sridtype (sridid) ENABLE VALIDATE;
 
-ALTER TABLE OBSERVATIONSTYPE ADD
-CONSTRAINT OBSERVATIONSTYPE_U01
-UNIQUE (OBSERVATIONSTYPEID)
-USING INDEX OBSERVATIONSTYPE_IDX_001
-ENABLE VALIDATE;
+ALTER TABLE
+  koordinat
+ADD
+  CONSTRAINT punktid_con_0001 FOREIGN KEY (punktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
+ALTER TABLE
+  observation
+ADD
+  CONSTRAINT Observation_sp_con_0001 FOREIGN KEY (sigtepunktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
-ALTER TABLE KOORDINAT ADD
-CONSTRAINT KOORDINAT_R01
-FOREIGN KEY (SRIDID)
-REFERENCES SRIDTYPE (SRIDID)
-ENABLE VALIDATE;
+ALTER TABLE
+  observation
+ADD
+  CONSTRAINT observation_op1_con_0001 FOREIGN KEY (opstillingspunktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
-ALTER TABLE KOORDINAT ADD
-CONSTRAINT PUNKTID_CON_0001
-FOREIGN KEY (PUNKTID)
-REFERENCES PUNKT (ID)
-ENABLE VALIDATE;
+ALTER TABLE
+  observation
+ADD
+  CONSTRAINT observation_r01 FOREIGN KEY (observationstypeid) REFERENCES observationstype (observationstypeid) ENABLE VALIDATE;
 
-ALTER TABLE OBSERVATION ADD
-CONSTRAINT OBSERVATION_SP_CON_0001
-FOREIGN KEY (SIGTEPUNKTID)
-REFERENCES PUNKT (ID)
-ENABLE VALIDATE;
+ALTER TABLE
+  punktinfo
+ADD
+  CONSTRAINT punktinfo_con_001 FOREIGN KEY (punktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
-ALTER TABLE OBSERVATION ADD
-CONSTRAINT OBSERVATION_OP1_CON_0001
-FOREIGN KEY (OPSTILLINGSPUNKTID)
-REFERENCES PUNKT (ID)
-ENABLE VALIDATE;
+ALTER TABLE
+  punktinfo
+ADD
+  CONSTRAINT punktinfo_r01 FOREIGN KEY (infotypeid) REFERENCES punktinfotype (infotypeid) ENABLE VALIDATE;
 
-ALTER TABLE OBSERVATION ADD
-CONSTRAINT OBSERVATION_R01
-FOREIGN KEY (OBSERVATIONSTYPEID)
-REFERENCES OBSERVATIONSTYPE (OBSERVATIONSTYPEID)
-ENABLE VALIDATE;
+ALTER TABLE
+  sagsinfo
+ADD
+  CONSTRAINT sagsinfo_r01 FOREIGN KEY (sagsid) REFERENCES sag (id) ENABLE VALIDATE;
 
-ALTER TABLE PUNKTINFO ADD
-CONSTRAINT PUNKTINFO_CON_001
-FOREIGN KEY (PUNKTID)
-REFERENCES PUNKT (ID)
-ENABLE VALIDATE;
+ALTER TABLE
+  sagsevent
+ADD
+  CONSTRAINT sagsevent_r01 FOREIGN KEY (sagsid) REFERENCES sag (id) ENABLE VALIDATE;
 
-ALTER TABLE PUNKTINFO ADD
-CONSTRAINT PUNKTINFO_R01
-FOREIGN KEY (INFOTYPEID)
-REFERENCES PUNKTINFOTYPE (INFOTYPEID)
-ENABLE VALIDATE;
+ALTER TABLE
+  sagsevent
+ADD
+  CONSTRAINT sagsevent_r02 FOREIGN KEY (eventtypeid) REFERENCES eventtype (eventtypeid) ENABLE VALIDATE;
+
+ALTER TABLE
+  sagseventinfo
+ADD
+  CONSTRAINT sagseventinfo_r01 FOREIGN KEY (sagseventid) REFERENCES sagsevent (id) ENABLE VALIDATE;
+
 
 -- Diverse index
 
 CREATE INDEX idx_punktinfo_pid ON punktinfo(punktid);
+
 CREATE INDEX idx_koordinat_pid ON koordinat(punktid);
+
 CREATE INDEX idx_geomobj_pid ON geometriobjekt(punktid);
 
 CREATE INDEX idx_observ_opid ON observation(opstillingspunktid);
+
 CREATE INDEX idx_observ_spid ON observation(sigtepunktid);
 
 CREATE INDEX idx_punktinfotyp_anv ON punktinfotype(anvendelse);
+
 CREATE INDEX idx_punktinfotyp_typ ON punktinfotype(infotype);
 
 
 --- --  Dette bør lægges på ifm indlæsning fra REFGEO
-create unique index geomobj_datopid on geometriobjekt(punktid, registreringfra);
+CREATE UNIQUE INDEX geomobj_datopid ON geometriobjekt(punktid, registreringfra);
 
 -- Constraint der tjekker at registreringtil er større end registreringfra
-ALTER TABLE BEREGNING ADD
-CONSTRAINT BEREGNING_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
+ALTER TABLE
+  beregning
+ADD
+  CONSTRAINT beregning_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
-ALTER TABLE GEOMETRIOBJEKT ADD
-CONSTRAINT GEOMETRIOBJEKT_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
+ALTER TABLE
+  geometriobjekt
+ADD
+  CONSTRAINT geometriobjekt_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
-ALTER TABLE KOORDINAT ADD
-CONSTRAINT KOORDINAT_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
+ALTER TABLE
+  koordinat
+ADD
+  CONSTRAINT koordinat_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
-ALTER TABLE OBSERVATION ADD
-CONSTRAINT OBSERVATION_con_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
+ALTER TABLE
+  observation
+ADD
+  CONSTRAINT observation_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
+ALTER TABLE
+  punkt
+ADD
+  CONSTRAINT punkt_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
-ALTER TABLE PUNKT ADD
-CONSTRAINT PUNKT_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
+ALTER TABLE
+  punktinfo
+ADD
+  CONSTRAINT punktinfo_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
+ALTER TABLE
+  sagsinfo
+ADD
+  CONSTRAINT sagsinfo_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
-ALTER TABLE PUNKTINFO ADD
-CONSTRAINT PUNKTINFO_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
+ALTER TABLE
+  sagseventinfo
+ADD
+  CONSTRAINT sagseventinfo_con_0001 CHECK (
+    nvl(
+      registreringtil,
+      to_timestamp_tz(
+        '31/12/2099 00:00:00.000000 +1:00',
+        'dd/mm/yyyy hh24:mi:ss.ff tzh:tzm'
+      )
+    ) >= registreringfra
+  ) ENABLE VALIDATE;
 
-ALTER TABLE SAG ADD (
-CONSTRAINT SAG_U01
-UNIQUE (ID)
-ENABLE VALIDATE);
-
-ALTER TABLE SAGSINFO ADD (
-CONSTRAINT SAGSINFO_R01
-FOREIGN KEY (SAGSID)
-REFERENCES SAG (ID)
-ENABLE VALIDATE);
-
-
-ALTER TABLE SAGSINFO ADD
-CONSTRAINT SAGSINFO_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
-
--- Constraint der sikrer at et sagsevent henviser til en eksisterende sag
-ALTER TABLE SAGSEVENT ADD
-CONSTRAINT SAGSEVENT_R01
-FOREIGN KEY (SAGSID)
-REFERENCES SAG (ID)
-ENABLE VALIDATE;
-
-ALTER TABLE SAGSEVENT ADD
-CONSTRAINT SAGSEVENT_R02
-FOREIGN KEY (EVENTTYPEID)
-REFERENCES EVENTTYPE (EVENTTYPEID)
-ENABLE VALIDATE;
-
-ALTER TABLE SAGSEVENT ADD (
-CONSTRAINT SAGSEVENT_U01
-UNIQUE (ID)
-ENABLE VALIDATE);
-
-ALTER TABLE SAGSEVENTINFO ADD
-CONSTRAINT SAGSEVENTINFO_CON_0001
-CHECK (nvl(registreringtil,to_timestamp_tz('31/12/2099 00:00:00.000000 +1:00','dd/mm/yyyy hh24:mi:ss.ff tzh:tzm')) >= registreringfra)
-ENABLE VALIDATE;
-
-ALTER TABLE SAGSEVENTINFO ADD (
-CONSTRAINT SAGSEVENTINFO_R01
-FOREIGN KEY (SAGSEVENTID)
-REFERENCES SAGSEVENT (ID)
-ENABLE VALIDATE);
 
 
 -----------------------------------------------------------------------------------------
@@ -455,38 +615,41 @@ ENABLE VALIDATE);
 -----------------------------------------------------------------------------------------
 
 
-COMMENT ON TABLE BEREGNING IS 'Sammenknytter beregnede koordinater med de anvendte observationer.';
-COMMENT ON COLUMN BEREGNING.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN BEREGNING.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN BEREGNING.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN BEREGNING.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN BEREGNING_KOORDINAT.KOORDINATOBJEKTID IS 'Udpegning af de koordinater der er indgået i en beregning.';
-COMMENT ON COLUMN BEREGNING_OBSERVATION.OBSERVATIONOBJEKTID IS 'Udpegning af de observationer der er brugt i en beregning.';
-COMMENT ON TABLE EVENTTYPE IS 'Objekt til at holde en liste over lovlige typer af events i fikspunktsforvaltningssystemet, samt en beskrivelse hvad eventtypen dækker over.';
-COMMENT ON COLUMN EVENTTYPE.BESKRIVELSE IS 'Kort beskrivelse af en eventtype.';
-COMMENT ON COLUMN EVENTTYPE.EVENT IS 'Navngivning af en eventtype.';
-COMMENT ON COLUMN EVENTTYPE.EVENTTYPEID IS 'Identifikation af typen af en sagsevent.';
-COMMENT ON TABLE GEOMETRIOBJEKT IS 'Objekt indeholdende et punkts placeringsgeometri.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.GEOMETRI IS 'Geometri til brug for visning i f.eks et GIS system.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.PUNKTID IS 'Punkt som har en placeringsgeometri tilknyttet.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN GEOMETRIOBJEKT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON TABLE KOORDINAT IS 'Generisk 4D koordinat.';
-COMMENT ON COLUMN KOORDINAT.PUNKTID IS 'Punkt som koordinaten hører til.';
-COMMENT ON COLUMN KOORDINAT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN KOORDINAT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN KOORDINAT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN KOORDINAT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN KOORDINAT.SRIDID IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
-COMMENT ON COLUMN KOORDINAT.SX IS 'A posteriori spredning på førstekoordinaten.';
-COMMENT ON COLUMN KOORDINAT.SY IS 'A posteriori spredning på andenkoordinaten.';
-COMMENT ON COLUMN KOORDINAT.SZ IS 'A posteriori spredning på tredjekoordinaten.';
-COMMENT ON COLUMN KOORDINAT.T IS 'Observationstidspunktet.';
-COMMENT ON COLUMN KOORDINAT.FEJLMELDT IS 'Markering af at en koordinat er udgået fordi den er fejlbehæftet';
-COMMENT ON COLUMN KOORDINAT.TRANSFORMERET IS 'Angivelse om positionen er målt, eller transformeret fra et andet koordinatsystem';
-COMMENT ON COLUMN KOORDINAT.ARTSKODE IS 'Fra REFGEO. Værdierne skal forstås som følger:
+COMMENT ON TABLE beregning IS 'Sammenknytter beregnede koordinater med de anvendte observationer.';
+COMMENT ON COLUMN beregning.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN beregning.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN beregning.sagseventfraid IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN beregning.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN beregning_koordinat.koordinatobjektid IS 'Udpegning af de koordinater der er indgået i en beregning.';
+COMMENT ON COLUMN beregning_observation.observationobjektid IS 'Udpegning af de observationer der er brugt i en beregning.';
+
+COMMENT ON TABLE eventtype IS 'Objekt til at holde en liste over lovlige typer af events i fikspunktsforvaltningssystemet, samt en beskrivelse hvad eventtypen dækker over.';
+COMMENT ON COLUMN eventtype.beskrivelse IS 'Kort beskrivelse af en eventtype.';
+COMMENT ON COLUMN eventtype.event IS 'Navngivning af en eventtype.';
+COMMENT ON COLUMN eventtype.eventtypeid IS 'Identifikation af typen af en sagsevent.';
+
+COMMENT ON TABLE geometriobjekt IS 'Objekt indeholdende et punkts placeringsgeometri.';
+COMMENT ON COLUMN geometriobjekt.geometri IS 'Geometri til brug for visning i f.eks et GIS system.';
+COMMENT ON COLUMN geometriobjekt.punktid IS 'Punkt som har en placeringsgeometri tilknyttet.';
+COMMENT ON COLUMN geometriobjekt.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN geometriobjekt.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN geometriobjekt.sagseventfraid IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN geometriobjekt.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+
+COMMENT ON TABLE koordinat IS 'Generisk 4D koordinat.';
+COMMENT ON COLUMN koordinat.punktid IS 'Punkt som koordinaten hører til.';
+COMMENT ON COLUMN koordinat.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN koordinat.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN koordinat.sagseventfraid IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN koordinat.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN koordinat.sridid IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
+COMMENT ON COLUMN koordinat.sx IS 'A posteriori spredning på førstekoordinaten.';
+COMMENT ON COLUMN koordinat.sy IS 'A posteriori spredning på andenkoordinaten.';
+COMMENT ON COLUMN koordinat.sz IS 'A posteriori spredning på tredjekoordinaten.';
+COMMENT ON COLUMN koordinat.t IS 'Observationstidspunktet.';
+COMMENT ON COLUMN koordinat.fejlmeldt IS 'Markering af at en koordinat er udgået fordi den er fejlbehæftet';
+COMMENT ON COLUMN koordinat.transformeret IS 'Angivelse om positionen er målt, eller transformeret fra et andet koordinatsystem';
+COMMENT ON COLUMN koordinat.artskode IS 'Fra REFGEO. Værdierne skal forstås som følger:
 
  artskode = 1 control point in fundamental network, first order.
  artskode = 2 control point in superior plane network.
@@ -500,107 +663,118 @@ COMMENT ON COLUMN KOORDINAT.ARTSKODE IS 'Fra REFGEO. Værdierne skal forstås so
  artskode = 9 location coordinate or location height.
 
  Artskode er kun tilgængelig for koordinater der stammer fra REFGEO.';
-COMMENT ON COLUMN KOORDINAT.X IS 'Førstekoordinat.';
-COMMENT ON COLUMN KOORDINAT.Y IS 'Andenkoordinat.';
-COMMENT ON COLUMN KOORDINAT.Z IS 'Tredjekoordinat.';
-COMMENT ON TABLE OBSERVATION IS 'Generisk observationsobjekt indeholdende informationer om en observation.';
-COMMENT ON COLUMN OBSERVATION.ANTAL IS 'Antal gentagne observationer hvoraf en middelobservationen er fremkommet.';
-COMMENT ON COLUMN OBSERVATION.GRUPPE IS 'ID der angiver observationsgruppen for en observation der indgår i en gruppe.';
-COMMENT ON COLUMN OBSERVATION.OBSERVATIONSTIDSPUNKT IS 'Tidspunktet hvor observationen er foretaget';
-COMMENT ON COLUMN OBSERVATION.OBSERVATIONSTYPEID IS 'Identifikation af en observations type.';
-COMMENT ON COLUMN OBSERVATION.OPSTILLINGSPUNKTID IS 'Udpegning af det punkt der er anvendt ved opstilling ved en observation.';
-COMMENT ON COLUMN OBSERVATION.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN OBSERVATION.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN OBSERVATION.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN OBSERVATION.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN OBSERVATION.SIGTEPUNKTID IS 'Udpegning af punkt der er sigtet til ved en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE1 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE10 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE11 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE12 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE13 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE14 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE15 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE2 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE3 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE4 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE5 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE6 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE7 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE8 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE9 IS 'En værdi for en observation.';
-COMMENT ON TABLE OBSERVATIONSTYPE IS 'Objekttype til beskrivelse af hvorledes en Observation skal læses, ud fra typen af observation.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.BESKRIVELSE IS 'Overordnet beskrivelse af denne observationstype.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.OBSERVATIONSTYPE IS 'Kortnavn for observationstypen, fx dH';
-COMMENT ON COLUMN OBSERVATIONSTYPE.OBSERVATIONSTYPEID IS 'Identifikation af observationenst type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.SIGTEPUNKT IS 'Indikator for om Sigtepunkt anvendes for denne observationstype.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE1 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE10 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE11 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE12 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE13 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE14 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE15 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE2 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE3 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE4 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE5 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE6 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE7 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE8 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE9 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON TABLE PUNKT IS 'Abstrakt repræsentation af et fysisk punkt. Knytter alle punktinformationer sammen.';
-COMMENT ON COLUMN PUNKT.ID IS 'Persistent unik nøgle.';
-COMMENT ON COLUMN PUNKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN PUNKT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN PUNKT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN PUNKT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON TABLE PUNKTINFO IS 'Generisk information om et punkt.';
-COMMENT ON COLUMN PUNKTINFO.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
-COMMENT ON COLUMN PUNKTINFO.PUNKTID IS 'Punktet som punktinfo er holder information om.';
-COMMENT ON COLUMN PUNKTINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN PUNKTINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN PUNKTINFO.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN PUNKTINFO.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN PUNKTINFO.TAL IS 'Værdien for numeriske informationselementer';
-COMMENT ON COLUMN PUNKTINFO.TEKST IS 'Værdien for tekstinformationselementer';
-COMMENT ON TABLE PUNKTINFOTYPE IS 'Udfaldsrum for punktinforobjekter med definition af hvordan PunktInfo skal læses og beskrivelse af typen af punktinfo.';
-COMMENT ON COLUMN PUNKTINFOTYPE.ANVENDELSE IS 'Er det reelTal, tekst, eller ingen af disse, der angiver værdien';
-COMMENT ON COLUMN PUNKTINFOTYPE.BESKRIVELSE IS 'Beskrivelse af denne informationstypes art.';
-COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPE IS 'Arten af dette informationselement';
-COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
-COMMENT ON TABLE SAG IS 'Samling af administrativt relaterede sagshændelser.';
-COMMENT ON COLUMN SAG.ID IS 'Persistent unik nøgle.';
-COMMENT ON COLUMN SAG.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON TABLE SAGSEVENT IS 'Udvikling i sag som kan, men ikke behøver, medføre opdateringer af fikspunktregisterobjekter.';
-COMMENT ON COLUMN SAGSEVENT.EVENTTYPEID IS 'Identifikation af typen af en sagsevent.';
-COMMENT ON COLUMN SAGSEVENT.ID IS 'Persistent unik nøgle.';
-COMMENT ON COLUMN SAGSEVENT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN SAGSEVENT.SAGSID IS 'Udpegning af den sag i fikspunktsforvalningssystemet som en event er foretaget i.';
-COMMENT ON TABLE SAGSEVENTINFO IS 'Informationer der knytter sig til en et sagsevent.';
-COMMENT ON COLUMN SAGSEVENTINFO.BESKRIVELSE IS 'Specifik beskrivelse af den aktuelle fremdrift.';
-COMMENT ON COLUMN SAGSEVENTINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN SAGSEVENTINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN SAGSEVENTINFO.SAGSEVENTID IS 'Den sagsevent som sagseventinfo har information om.';
-COMMENT ON COLUMN SAGSEVENTINFO_HTML.HTML IS 'Generisk operatørlæsbart orienterende rapportmateriale.';
-COMMENT ON TABLE SAGSEVENTINFO_MATERIALE IS 'Eksternt placeret materiale knyttet til en event';
-COMMENT ON COLUMN SAGSEVENTINFO_MATERIALE.MD5SUM IS 'Sum brugt til at kontrollere materialets integritet.';
-COMMENT ON COLUMN SAGSEVENTINFO_MATERIALE.STI IS 'Placering af materialet.';
-COMMENT ON TABLE SAGSINFO IS 'Samling af administrativt relaterede sagshændelser.';
-COMMENT ON COLUMN SAGSINFO.AKTIV IS 'Markerer om sagen er åben eller lukket.';
-COMMENT ON COLUMN SAGSINFO.BEHANDLER IS 'Angivelse af en sagsbehandler.';
-COMMENT ON COLUMN SAGSINFO.BESKRIVELSE IS 'Kort beskrivelse af en fikspunktssag.';
-COMMENT ON COLUMN SAGSINFO.JOURNALNUMMER IS 'Sagsmappeidentifikation i opmålings- og beregningssagsregistret.';
-COMMENT ON COLUMN SAGSINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN SAGSINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN SAGSINFO.SAGSID IS 'Den sag som sagsinfo holder information for.';
-COMMENT ON TABLE SRIDTYPE IS 'Udfaldsrum for SRID-koordinatbeskrivelser.';
-COMMENT ON COLUMN SRIDTYPE.BESKRIVELSE IS 'Generel beskrivelse af systemet.';
-COMMENT ON COLUMN SRIDTYPE.SRID IS 'Den egentlige referencesystemindikator.';
-COMMENT ON COLUMN SRIDTYPE.SRIDID IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
-COMMENT ON COLUMN SRIDTYPE.X IS 'Beskrivelse af x-koordinatens indhold';
-COMMENT ON COLUMN SRIDTYPE.Y IS 'Beskrivelse af y-koordinatens indhold.';
-COMMENT ON COLUMN SRIDTYPE.Z IS 'Beskrivelse af z-koordinatens indhold.';
+COMMENT ON COLUMN koordinat.x IS 'Førstekoordinat.';
+COMMENT ON COLUMN koordinat.y IS 'Andenkoordinat.';
+COMMENT ON COLUMN koordinat.z IS 'Tredjekoordinat.';
+
+COMMENT ON TABLE observation IS 'Generisk observationsobjekt indeholdende informationer om en observation.';
+COMMENT ON COLUMN observation.antal IS 'Antal gentagne observationer hvoraf en middelobservationen er fremkommet.';
+COMMENT ON COLUMN observation.gruppe IS 'ID der angiver observationsgruppen for en observation der indgår i en gruppe.';
+COMMENT ON COLUMN observation.observationstidspunkt IS 'Tidspunktet hvor observationen er foretaget';
+COMMENT ON COLUMN observation.observationstypeid IS 'Identifikation af en observations type.';
+COMMENT ON COLUMN observation.opstillingspunktid IS 'Udpegning af det punkt der er anvendt ved opstilling ved en observation.';
+COMMENT ON COLUMN observation.registreringfrA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN observation.registreringtiL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN observation.sagseventfraid IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN observation.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN observation.sigtepunktid IS 'Udpegning af punkt der er sigtet til ved en observation.';
+COMMENT ON COLUMN observation.value1 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value2 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value3 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value4 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value5 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value6 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value7 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value8 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value9 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value10 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value11 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value12 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value13 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value14 IS 'En værdi for en observation.';
+COMMENT ON COLUMN observation.value15 IS 'En værdi for en observation.';
+
+COMMENT ON TABLE observationstype IS 'Objekttype til beskrivelse af hvorledes en Observation skal læses, ud fra typen af observation.';
+COMMENT ON COLUMN observationstype.beskrivelse IS 'Overordnet beskrivelse af denne observationstype.';
+COMMENT ON COLUMN observationstype.observationstype IS 'Kortnavn for observationstypen, fx dH';
+COMMENT ON COLUMN observationstype.observationstypeid IS 'Identifikation af observationenst type.';
+COMMENT ON COLUMN observationstype.sigtepunkt IS 'Indikator for om Sigtepunkt anvendes for denne observationstype.';
+COMMENT ON COLUMN observationstype.value1 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value2 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value3 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value4 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value5 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value6 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value7 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value8 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value9 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value10 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value11 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value12 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value13 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value14 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN observationstype.value15 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+
+COMMENT ON TABLE punkt IS 'Abstrakt repræsentation af et fysisk punkt. Knytter alle punktinformationer sammen.';
+COMMENT ON COLUMN punkt.id IS 'Persistent unik nøgle.';
+COMMENT ON COLUMN punkt.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN punkt.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN punkt.sagseventfraid IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN punkt.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+
+COMMENT ON TABLE punktinfo IS 'Generisk information om et punkt.';
+COMMENT ON COLUMN punktinfo.infotypeid IS 'Unik ID for typen af Punktinfo.';
+COMMENT ON COLUMN punktinfo.punktid IS 'Punktet som punktinfo er holder information om.';
+COMMENT ON COLUMN punktinfo.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN punktinfo.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN punktinfo.sagseventfraid IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN punktinfo.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN punktinfo.tal IS 'Værdien for numeriske informationselementer';
+COMMENT ON COLUMN punktinfo.tekst IS 'Værdien for tekstinformationselementer';
+
+COMMENT ON TABLE punktinfotype IS 'Udfaldsrum for punktinforobjekter med definition af hvordan PunktInfo skal læses og beskrivelse af typen af punktinfo.';
+COMMENT ON COLUMN punktinfotype.anvendelse IS 'Er det reelTal, tekst, eller ingen af disse, der angiver værdien';
+COMMENT ON COLUMN punktinfotype.beskrivelse IS 'Beskrivelse af denne informationstypes art.';
+COMMENT ON COLUMN punktinfotype.infotype IS 'Arten af dette informationselement';
+COMMENT ON COLUMN punktinfotype.infotypeid IS 'Unik ID for typen af Punktinfo.';
+
+COMMENT ON TABLE sag IS 'Samling af administrativt relaterede sagshændelser.';
+COMMENT ON COLUMN sag.id IS 'Persistent unik nøgle.';
+COMMENT ON COLUMN sag.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+
+COMMENT ON TABLE sagsevent IS 'Udvikling i sag som kan, men ikke behøver, medføre opdateringer af fikspunktregisterobjekter.';
+COMMENT ON COLUMN sagsevent.eventtypeid IS 'Identifikation af typen af en sagsevent.';
+COMMENT ON COLUMN sagsevent.id IS 'Persistent unik nøgle.';
+COMMENT ON COLUMN sagsevent.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN sagsevent.sagsid IS 'Udpegning af den sag i fikspunktsforvalningssystemet som en event er foretaget i.';
+
+COMMENT ON TABLE sagseventinfo IS 'Informationer der knytter sig til en et sagsevent.';
+COMMENT ON COLUMN sagseventinfo.beskrivelse IS 'Specifik beskrivelse af den aktuelle fremdrift.';
+COMMENT ON COLUMN sagseventinfo.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN sagseventinfo.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN Sagseventinfo.sagseventid IS 'Den sagsevent som sagseventinfo har information om.';
+COMMENT ON COLUMN sagseventinfo_html.html IS 'Generisk operatørlæsbart orienterende rapportmateriale.';
+
+COMMENT ON TABLE sagseventinfo_materiale IS 'Eksternt placeret materiale knyttet til en event';
+COMMENT ON COLUMN sagseventinfo_materiale.md5sum IS 'Sum brugt til at kontrollere materialets integritet.';
+COMMENT ON COLUMN sagseventinfo_materiale.sti IS 'Placering af materialet.';
+
+COMMENT ON TABLE sagsinfo IS 'Samling af administrativt relaterede sagshændelser.';
+COMMENT ON COLUMN sagsinfo.aktiv IS 'Markerer om sagen er åben eller lukket.';
+COMMENT ON COLUMN sagsinfo.behandler IS 'Angivelse af en sagsbehandler.';
+COMMENT ON COLUMN sagsinfo.beskrivelse IS 'Kort beskrivelse af en fikspunktssag.';
+COMMENT ON COLUMN sagsinfo.journalnummer IS 'Sagsmappeidentifikation i opmålings- og beregningssagsregistret.';
+COMMENT ON COLUMN sagsinfo.registreringfra IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN sagsinfo.registreringtil IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN sagsinfo.sagsid IS 'Den sag som sagsinfo holder information for.';
+
+COMMENT ON TABLE sridtype IS 'Udfaldsrum for SRID-koordinatbeskrivelser.';
+COMMENT ON COLUMN sridtype.beskrivelse IS 'Generel beskrivelse af systemet.';
+COMMENT ON COLUMN sridtype.srid IS 'Den egentlige referencesystemindikator.';
+COMMENT ON COLUMN sridtype.sridid IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
+COMMENT ON COLUMN sridtype.x IS 'Beskrivelse af x-koordinatens indhold';
+COMMENT ON COLUMN sridtype.y IS 'Beskrivelse af y-koordinatens indhold.';
+COMMENT ON COLUMN sridtype.z IS 'Beskrivelse af z-koordinatens indhold.';
 
 
 -----------------------------------------------------------------------------------------
@@ -608,547 +782,695 @@ COMMENT ON COLUMN SRIDTYPE.Z IS 'Beskrivelse af z-koordinatens indhold.';
 -----------------------------------------------------------------------------------------
 
 -- Triggere der sikrer at kun registreringtil kan opdateres i en tabel
-CREATE OR REPLACE TRIGGER AUD#BEREGNING
-after update ON BEREGNING
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+CREATE OR REPLACE TRIGGER aud#beregning
+AFTER UPDATE ON beregning FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
+  IF :new.sagseventfraid != :old.sagseventfraid THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
+END;
 /
 
 
-CREATE OR REPLACE TRIGGER AUD#GEOMETRIOBJEKT
-after update ON GEOMETRIOBJEKT
-for each row
-begin
+CREATE OR REPLACE TRIGGER aud#geometriobjekt
+AFTER UPDATE ON geometriobjekt FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
 
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
 
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.sagseventfraid != :old.sagseventfraid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
 
-IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.PUNKTID != :old.PUNKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
+  IF :new.punktid != :old.punktid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+END;
 /
 
-CREATE OR REPLACE TRIGGER AUD#KOORDINAT
-after update ON KOORDINAT
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+CREATE OR REPLACE TRIGGER aud#koordinat
+AFTER UPDATE ON koordinat
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.SRIDID != :old.SRIDID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.sridid != :old.sridid THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.SX != :old.SX THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.sx != :old.sx THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.SY != :old.SY THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.sy != :old.sy THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
+  IF :new.sz != :old.sz THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.SZ != :old.SZ THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.t != :old.t THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.T != :old.T THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.transformeret != :old.transformeret THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.TRANSFORMERET != :old.TRANSFORMERET THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.x != :old.x THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.X != :old.X THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.y != :old.y THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
+  IF :new.z != :old.z THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.Y != :old.Y THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.sagseventfraid != :old.sagseventfraid THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.Z != :old.Z THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.punktid != :old.punktid THEN
+    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+  END IF;
 
-IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.PUNKTID != :old.PUNKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.FEJLMELDT != :old.FEJLMELDT AND :new.REGISTRERINGTIL IS NULL THEN
+  IF :new.fejlmeldt != :old.fejlmeldt AND :new.registreringtil IS NULL THEN
     RAISE_APPLICATION_ERROR(-20000, 'Registreringtil skal sættes når en koordinat fejlmeldes');
-END IF;
+  END IF;
 
-end;
+END;
+/
+
+CREATE OR REPLACE TRIGGER aud#observation
+AFTER UPDATE ON observation
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.antal != :old.antal THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.gruppe != :old.gruppe THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.observationstypeid != :old.observationstypeid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value1 != :old.value1 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value2 != :old.value2 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value3 != :old.value3 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value4 != :old.value4 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value5 != :old.value5 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value6 != :old.value6 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value7 != :old.value7 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value8 != :old.value8 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value9 != :old.value9 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value10 != :old.value10 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value11 != :old.value11 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value12 != :old.value12 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value13 != :old.value13 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value14 != :old.value14 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.value15 != :old.value15 THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.sagseventfraid != :old.sagseventfraid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.opstillingspunktid != :old.opstillingspunktid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.sigtepunktid != :old.sigtepunktid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+END;
+/
+
+-- Trigger der sikrer at indeholdet i tabellen KOORDINAT matcher hvad der er
+-- specificeret omkring SRID i SRIDTYPE tabellen
+CREATE OR REPLACE TRIGGER aiu#koordinat
+AFTER INSERT OR UPDATE ON koordinat
+FOR EACH ROW
+DECLARE
+  valX VARCHAR2(4000) := '';
+  valY VARCHAR2(4000) := '';
+  valZ VARCHAR2(4000) := '';
+BEGIN
+  SELECT x, y, z
+  INTO valX, valY, valZ
+  FROM
+    sridtype a
+  WHERE
+    a.sridid = :new.sridid;
+
+  IF (:new.x IS NULL OR :new.sx IS NULL) AND valX IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Hverken X eller SX må ikke være NULL');
+  END IF;
+
+  IF (:new.y IS NULL OR :new.sy IS NULL) AND valY IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Hverken Y eller SY må ikke være NULL');
+  END IF;
+
+  IF (:new.Z IS NULL OR :new.SZ IS NULL) AND valZ IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Hverken Z eller SZ må ikke være NULL');
+  END IF;
+END;
+/
+
+CREATE OR REPLACE TRIGGER aud#punkt
+AFTER UPDATE ON punkt
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.id != :old.id THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.sagseventfraid != :old.sagseventfraid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+END;
 /
 
 
-CREATE OR REPLACE TRIGGER AUD#OBSERVATION
-after update ON OBSERVATION
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+CREATE OR REPLACE TRIGGER aud#sag
+BEFORE UPDATE ON sag
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
 
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.id != :old.id THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
 
-IF :new.ANTAL != :old.ANTAL THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.GRUPPE != :old.GRUPPE THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-
-IF :new.OBSERVATIONSTYPEID != :old.OBSERVATIONSTYPEID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE1 != :old.VALUE1 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE2 != :old.VALUE2 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE3 != :old.VALUE3 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-
-IF :new.VALUE4 != :old.VALUE4 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE5 != :old.VALUE5 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE6 != :old.VALUE6 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE7 != :old.VALUE7 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE8 != :old.VALUE8 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE9 != :old.VALUE9 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE10 != :old.VALUE10 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE11 != :old.VALUE11 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE12 != :old.VALUE12 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE13 != :old.VALUE13 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE14 != :old.VALUE14 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.VALUE15 != :old.VALUE15 THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.OPSTILLINGSPUNKTID != :old.OPSTILLINGSPUNKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.SIGTEPUNKTID != :old.SIGTEPUNKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
-/
-
--- Trigger der sikrer at indeholdet i tabellen KOORDINAT matcher hvad der er specificeret omkring SRID i SRIDTYPE tabellen
-CREATE OR REPLACE TRIGGER AIU#KOORDINAT
-after insert Or UPDATE ON KOORDINAT
-for each row
-declare
-   valX varchar2(4000):= '';
-   valY varchar2(4000):= '';
-   valZ varchar2(4000):= '';
-begin
-
-  select x,
-         y,
-         z into
-         valX,
-         valY,
-         valZ
-  from sridtype a
-  where A.SRIDID = :new.SRIDID;
-
-
-  if (:new.X is null OR :new.SX is NULL) and valX is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Hverken X eller SX må ikke være NULL');
-  end if;
-
-  if (:new.Y is null OR :new.SY is NULL) and valY is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Hverken Y eller SY må ikke være NULL');
-  end if;
-
-  if (:new.Z is null OR :new.SZ is NULL) and valZ is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Hverken Z eller SZ må ikke være NULL');
-  end if;
-
-end;
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+END;
 /
 
 
-CREATE OR REPLACE TRIGGER AUD#PUNKT
-after update ON PUNKT
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+CREATE OR REPLACE TRIGGER aud#sagsevent
+AFTER UPDATE ON sagsevent
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(a) ');
+  END IF;
 
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.id != :old.id THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(b) ');
+  END IF;
 
-IF :new.ID != :old.ID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(c) ');
+  END IF;
 
-IF :new.SAGSEVENTFRAID != :old.SAGSEVENTFRAID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
-/
-
-
-CREATE OR REPLACE TRIGGER AUD#SAG
-before update ON SAG
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-
-IF :new.ID != :old.ID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
-/
-
-
-CREATE OR REPLACE TRIGGER AUD#SAGSEVENT
-after update ON SAGSEVENT
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(a) '); END IF;
-
-IF :new.ID != :old.ID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(b) '); END IF;
-
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(c) '); END IF;
-
-IF :new.SAGSID != :old.SAGSID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(d) '); END IF;
-
-end;
-/
-
-
-
-CREATE OR REPLACE TRIGGER AUD#SAGSEVENTINFO
-before update ON SAGSEVENTINFO
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.SAGSEVENTID != :old.SAGSEVENTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.BESKRIVELSE != :old.BESKRIVELSE THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
-/
-
-
-CREATE OR REPLACE TRIGGER AUD#SAGSINFO
-before update ON SAGSINFO
-for each row
-begin
-IF :new.OBJEKTID != :old.OBJEKTID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.SAGSID != :old.SAGSID THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.REGISTRERINGFRA != :old.REGISTRERINGFRA THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.AKTIV != :old.AKTIV THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.JOURNALNUMMER != :old.JOURNALNUMMER THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.BEHANDLER != :old.BEHANDLER THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-IF :new.BESKRIVELSE != :old.BESKRIVELSE THEN RAISE_APPLICATION_ERROR(-20000,'You cannot update this column '); END IF;
-
-end;
-/
-
-
--- Trigger der sikrer at sageevents kun knyttes til en aktiv sag
-CREATE OR REPLACE TRIGGER AID#SAGSEVENT
-after insert ON SAGSEVENT
-for each row
-declare
-cnt number := 0;
-begin
-
-  begin
-    select 1 into cnt
-    from sagsinfo
-    where aktiv = 'true'
-    and registreringtil is null
-    and sagsid = :new.sagsid;
-  exception when no_data_found then cnt:=0;
-  end;
-
-  if cnt = 0 then
-    RAISE_APPLICATION_ERROR(-20000,'Ingen aktiv sag fundet paa sagsid '||:new.sagsid);
+  IF :new.sagsid != :old.sagsid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(d) ');
   END IF;
 
 end;
 /
 
 
--- Trigger der skal sikre at inholdet i Observation-tabellen matcher hvad der er defineret observationstype-tabellen
-CREATE OR REPLACE TRIGGER AID#OBSERVATION
-after insert Or UPDATE ON OBSERVATION
-for each row
-declare
-   val1 varchar2(4000):= '';
-   val2 varchar2(4000):= '';
-   val3 varchar2(4000):= '';
-   val4 varchar2(4000):= '';
-   val5 varchar2(4000):= '';
-   val6 varchar2(4000):= '';
-   val7 varchar2(4000):= '';
-   val8 varchar2(4000):= '';
-   val9 varchar2(4000):= '';
+
+CREATE OR REPLACE TRIGGER aud#sagseventinfo
+BEFORE UPDATE ON sagseventinfo
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.sagseventid != :old.sagseventid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.beskrivelse != :old.beskrivelse THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+END;
+/
+
+
+CREATE OR REPLACE TRIGGER aud#sagsinfo
+BEFORE UPDATE ON sagsinfo
+FOR EACH ROW
+BEGIN
+  IF :new.objektid != :old.objektid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.sagsid != :old.sagsid THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.registreringfra != :old.registreringfra THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.aktiv != :old.aktiv THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.journalnummer != :old.journalnummer THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.behandler != :old.behandler THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+
+  IF :new.beskrivelse != :old.beskrivelse THEN
+    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+  END IF;
+END;
+/
+
+
+-- Trigger der sikrer at sageevents kun knyttes til en aktiv sag
+CREATE OR REPLACE TRIGGER aid#sagsevent
+AFTER INSERT ON sagsevent
+FOR EACH ROW
+DECLARE
+  cnt NUMBER := 0;
+BEGIN
+  BEGIN
+    SELECT
+      1 INTO cnt
+    FROM
+      sagsinfo
+    WHERE
+      aktiv = 'true'
+      AND registreringtil IS NULL
+      AND sagsid = :new.sagsid;
+  EXCEPTION
+    WHEN NO_DATA_FOUND THEN cnt := 0;
+  END;
+
+  IF cnt = 0 THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Ingen aktiv sag fundet paa sagsid ' || :new.sagsid);
+  END IF;
+END;
+/
+
+
+-- Trigger der skal sikre at inholdet i Observation-tabellen matcher hvad
+-- der er defineret observationstype-tabellen
+CREATE OR REPLACE TRIGGER aid#observation
+AFTER INSERT OR UPDATE ON observation
+FOR EACH ROW
+DECLARE
+   val1  varchar2(4000):= '';
+   val2  varchar2(4000):= '';
+   val3  varchar2(4000):= '';
+   val4  varchar2(4000):= '';
+   val5  varchar2(4000):= '';
+   val6  varchar2(4000):= '';
+   val7  varchar2(4000):= '';
+   val8  varchar2(4000):= '';
+   val9  varchar2(4000):= '';
    val10 varchar2(4000):= '';
    val11 varchar2(4000):= '';
    val12 varchar2(4000):= '';
    val13 varchar2(4000):= '';
    val14 varchar2(4000):= '';
    val15 varchar2(4000):= '';
-begin
+BEGIN
+  SELECT
+    value1, value2, value3, value4, value5,
+    value6, value7, value8, value9, value10,
+    value11, value12, value13, value14, value15
+  INTO
+    val1, val2, val3, val4, val5,
+    val6, val7, val8, val9, val10,
+    val11, val12, val13, val14, val15
+  FROM
+    observationstype A
+  WHERE
+    a.observationstypeid = :new.observationstypeid;
 
-  select value1,
-         value2,
-         value3,
-         value4,
-         value5,
-         value6,
-         value7,
-         value8,
-         value9,
-         value10,
-         value11,
-         value12,
-         value13,
-         value14,
-         value15 into
-         val1,
-         val2,
-         val3,
-         val4,
-         val5,
-         val6,
-         val7,
-         val8,
-         val9,
-         val10,
-         val11,
-         val12,
-         val13,
-         val14,
-         val15
-  from observationstype a
-  where A.OBSERVATIONSTYPEID = :new.OBSERVATIONSTYPEID;
+  IF :new.value1 IS NULL AND val1 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value1 må ikke være NULL');
+  END IF;
 
+  IF :new.value2 IS NULL AND val2 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value2 må ikke være NULL');
+  END IF;
 
-  if :new.value1 is null and val1 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value1 må ikke være NULL');
-  end if;
-  if :new.value2 is null and val2 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value2 må ikke være NULL');
-  end if;
-  if :new.value3 is null and val3 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value3 må ikke være NULL');
-  end if;
-  if :new.value4 is null and val4 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value4 må ikke være NULL');
-  end if;
-  if :new.value5 is null and val5 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value5 må ikke være NULL');
-  end if;
-  if :new.value6 is null and val6 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value6 må ikke være NULL');
-  end if;
-  if :new.value7 is null and val7 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value7 må ikke være NULL');
-  end if;
-  if :new.value8 is null and val8 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value8 må ikke være NULL');
-  end if;
-  if :new.value9 is null and val9 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value9 må ikke være NULL');
-  end if;
-  if :new.value10 is null and val10 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value10 må ikke være NULL');
-  end if;
-  if :new.value11 is null and val11 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value11 må ikke være NULL');
-  end if;
-  if :new.value12 is null and val12 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value12 må ikke være NULL');
-  end if;
-  if :new.value13 is null and val13 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value13 må ikke være NULL');
-  end if;
-  if :new.value14 is null and val14 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value14 må ikke være NULL');
-  end if;
-  if :new.value15 is null and val15 is not null THEN
-    RAISE_APPLICATION_ERROR(-20000,'Value15 må ikke være NULL');
-  end if;
+  IF :new.value3 IS NULL AND val3 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value3 må ikke være NULL');
+  END IF;
 
-end;
+  IF :new.value4 IS NULL AND val4 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value4 må ikke være NULL');
+  END IF;
+
+  IF :new.value5 IS NULL AND val5 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value5 må ikke være NULL');
+  END IF;
+
+  IF :new.value6 IS NULL AND val6 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value6 må ikke være NULL');
+  END IF;
+
+  IF :new.value7 IS NULL AND val7 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value7 må ikke være NULL');
+  END IF;
+
+  IF :new.value8 IS NULL AND val8 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value8 må ikke være NULL');
+  END IF;
+
+  IF :new.value9 IS NULL AND val9 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value9 må ikke være NULL');
+  END IF;
+
+  IF :new.value10 IS NULL AND val10 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value10 må ikke være NULL');
+  END IF;
+
+  IF :new.value11 IS NULL AND val11 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value11 må ikke være NULL');
+  END IF;
+
+  IF :new.value12 IS NULL AND val12 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value12 må ikke være NULL');
+  END IF;
+
+  IF :new.value13 IS NULL AND val13 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value13 må ikke være NULL');
+  END IF;
+
+  IF :new.value14 IS NULL AND val14 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value14 må ikke være NULL');
+  END IF;
+
+  IF :new.value15 IS NULL AND val15 IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Value15 må ikke være NULL');
+  END IF;
+END;
 /
 
 
--- Constraints der sikrer at namespacedelen er korrekt i PUNKTINFOTYPE og SRIDTYPE
-ALTER TABLE PUNKTINFOTYPE ADD
-CONSTRAINT PUNKTINFOTYPE_CON_0001
-CHECK (substr(infotype,1,instr(infotype,':')-1) in ('AFM','ATTR','IDENT','NET','REGION','SKITSE'))
-ENABLE
-VALIDATE;
-
-ALTER TABLE SRIDTYPE ADD
-CONSTRAINT OT_SRID_0001
-CHECK (substr(SRID,1,instr(SRID,':')-1) in ('DK','EPSG','GL','TS'))
-ENABLE VALIDATE;
-
 -- Sikrer at infotype i PUNKTINFO eksisterer i PUNKTINFOTYPE, og at data i PUNKTINFO matcher definition i PUNKTINFOTYPE
 -- og at tidligere version af punktinfo afregistreres korrekt ved indsættelse af ny
-CREATE OR REPLACE TRIGGER PUNKTINFO_TYPE_VALID_TRG
-BEFORE INSERT OR UPDATE
-ON PUNKTINFO
+CREATE OR REPLACE TRIGGER punktinfo_type_valid_trg
+BEFORE INSERT OR UPDATE ON punktinfo
 FOR EACH ROW
 DECLARE
   this_andv varchar2(10);
   cnt NUMBER;
-begin
-  begin
-    select anvendelse into this_andv
-    from punktinfotype
-    where infotypeid = :new.infotypeid;
+BEGIN
+  BEGIN
+    SELECT
+      anvendelse INTO this_andv
+    FROM
+      punktinfotype
+    WHERE
+      infotypeid = :new.infotypeid;
+  EXCEPTION
+    WHEN no_data_found THEN RAISE_APPLICATION_ERROR(-20000, 'No infotype found(!)');
+  END;
 
-   exception  when no_data_found then
-      RAISE_APPLICATION_ERROR(-20000,'No infotype found(!)');
-  end;
-
- if this_andv = 'FLAG' and (:new.TEKST is not null or :new.TAL is not null) THEN
-   RAISE_APPLICATION_ERROR(-20000,'Incorrect data (A)(!)');
-end if;
-
-if this_andv = 'TEKST' and:new.TAL is not null THEN
-   RAISE_APPLICATION_ERROR(-20000,'Incorrect data (B)(!)');
-end if;
-
-if this_andv = 'TAL' and:new.TEKST is not null THEN
-   RAISE_APPLICATION_ERROR(-20000,'Incorrect data (C)(!)');
-end if;
-
--- afregistrer forrige version af punktinfo når nyt indsættes
-IF :new.registreringtil IS NULL THEN
-  SELECT count(*) INTO cnt
-  FROM punktinfo
-  WHERE punktid = :new.PUNKTID AND infotypeid = :new.infotypeid AND registreringtil IS NULL;
-
-  IF cnt = 1 THEN
-    UPDATE punktinfo
-    SET registreringtil = :new.registreringfra, sagseventtilid = :new.sagseventfraid
-    WHERE objektid = (SELECT objektid FROM punktinfo WHERE punktid = :new.punktid AND infotypeid = :new.infotypeid AND registreringtil IS NULL);
+  IF this_andv = 'FLAG' AND (:new.tekst IS NOT NULL OR :new.tal IS NOT NULL) THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Incorrect data (A)(!)');
   END IF;
-END IF;
 
+  IF this_andv = 'TEKST' AND :new.tal IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Incorrect data (B)(!)');
+  END IF;
+
+  IF this_andv = 'TAL' AND :new.tekst IS NOT NULL THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Incorrect data (C)(!)');
+  END IF;
+
+  -- afregistrer forrige version af punktinfo når nyt indsættes
+  IF :new.registreringtil IS NULL THEN
+    SELECT
+      count(*) INTO cnt
+    FROM
+      punktinfo
+    WHERE
+      punktid = :new.punktid AND infotypeid = :new.infotypeid AND registreringtil IS NULL;
+
+    IF cnt = 1 THEN
+      UPDATE
+        punktinfo
+      SET
+        registreringtil = :new.registreringfra,
+        sagseventtilid = :new.sagseventfraid
+      WHERE
+        objektid = (
+          SELECT
+            objektid
+          FROM
+            punktinfo
+          WHERE
+            punktid = :new.punktid
+            AND infotypeid = :new.infotypeid
+            AND registreringtil IS NULL
+        );
+    END IF;
+  END IF;
 END;
 /
 
 
-CREATE OR REPLACE TRIGGER BID#PUNKT
-before insert ON PUNKT
-for each row
-declare
-cnt1 number;
-begin
-IF :new.REGISTRERINGFRA = :new.REGISTRERINGTIL THEN
+CREATE OR REPLACE TRIGGER bid#punkt
+BEFORE INSERT ON punkt
+FOR EACH ROW
+DECLARE
+  cnt1 NUMBER;
+BEGIN
+  IF :new.registreringfra = :new.registreringtil THEN
+    SELECT
+      count(*) INTO cnt1
+    FROM
+      punkt
+    WHERE
+      registreringtil = :new.registreringfra;
 
-  select count(*) into cnt1
-  from PUNKT
-  where REGISTRERINGTIL = :new.REGISTRERINGFRA;
-
-  if cnt1 = 0 THEN
-    RAISE_APPLICATION_ERROR(-20000,'No parent record found (!) ');
+    IF cnt1 = 0 THEN
+      RAISE_APPLICATION_ERROR(-20000,'No parent record found (!) ');
+    END IF;
   END IF;
-
-END IF;
-
-end;
+END;
 /
 
-CREATE OR REPLACE TRIGGER BID#KOORDINAT
-before insert ON KOORDINAT
-for each row
-declare
-cnt number;
-begin
-IF :new.REGISTRERINGFRA = :new.REGISTRERINGTIL THEN
-  select count(*) into cnt
-  from KOORDINAT
-  where REGISTRERINGTIL = :new.REGISTRERINGFRA;
+CREATE OR REPLACE TRIGGER bid#koordinat
+BEFORE INSERT ON koordinat
+FOR EACH ROW
+DECLARE
+  cnt NUMBER;
+BEGIN
+  IF :new.registreringfra = :new.registreringtil THEN
+    SELECT
+      count(*) INTO cnt
+    FROM
+      koordinat
+    WHERE
+      registreringtil = :new.registreringfra;
 
-  if cnt = 0 THEN
-    RAISE_APPLICATION_ERROR(-20000,'No parent record found (!) ');
+    if cnt = 0 THEN
+      RAISE_APPLICATION_ERROR(-20000,'No parent record found (!) ');
+    END IF;
   END IF;
-END IF;
 
-IF :new.REGISTRERINGTIL IS NULL THEN
-  select count(*) into cnt
-  from KOORDINAT
-  where punktid = :new.PUNKTID AND sridid = :new.sridid AND registreringtil IS NULL;
+  IF :new.registreringtil IS NULL THEN
+    SELECT
+      count(*) INTO cnt
+    FROM
+      koordinat
+    WHERE
+      punktid = :new.punktid
+      AND sridid = :new.sridid
+      AND registreringtil IS NULL;
 
-  if cnt = 1 THEN
-    UPDATE koordinat
-    SET registreringtil = :new.registreringfra, sagseventtilid = :new.sagseventfraid
-    WHERE objektid = (SELECT objektid FROM koordinat WHERE punktid = :new.punktid AND sridid = :new.sridid AND registreringtil IS NULL);
+    IF cnt = 1 THEN
+      UPDATE
+        koordinat
+      SET
+        registreringtil = :new.registreringfra,
+        sagseventtilid = :new.sagseventfraid
+      WHERE
+        objektid = (
+          SELECT
+            objektid
+          FROM
+            koordinat
+          WHERE
+            punktid = :new.punktid
+            AND sridid = :new.sridid
+            AND registreringtil IS NULL
+        );
+    END IF;
   END IF;
-END IF;
 
-IF :new.FEJLMELDT = 'true' THEN
-  RAISE_APPLICATION_ERROR(-20000, 'Indsættelse af fejlmeldt koordinat ikke tilladt');
-END IF;
-
-end;
+  IF :new.fejlmeldt = 'true' THEN
+    RAISE_APPLICATION_ERROR(-20000, 'Indsættelse af fejlmeldt koordinat ikke tilladt');
+  END IF;
+END;
 /
 
-CREATE OR REPLACE TRIGGER BID#SAGSINFO
+CREATE OR REPLACE TRIGGER bid#sagsinfo
 BEFORE INSERT ON sagsinfo
 FOR EACH ROW
 DECLARE
-cnt number;
+  cnt number;
 BEGIN
-IF :new.REGISTRERINGTIL IS NULL THEN
-  SELECT count(*) INTO cnt
-  FROM SAGSINFO
-  WHERE sagsid = :new.sagsid AND registreringtil IS NULL;
+  IF :new.registreringtil IS NULL THEN
+    SELECT
+      count(*) INTO cnt
+    FROM
+      sagsinfo
+    WHERE
+      sagsid = :new.sagsid
+      AND registreringtil IS NULL;
 
-  IF cnt = 1 THEN
-    UPDATE sagsinfo
-    SET registreringtil = :new.registreringfra
-    WHERE objektid = (
-        SELECT objektid
-        FROM sagsinfo
-        WHERE sagsid = :new.sagsid AND registreringtil IS NULL
-    );
+    IF cnt = 1 THEN
+    UPDATE
+      sagsinfo
+    SET
+      registreringtil = :new.registreringfra
+    WHERE
+      objektid = (
+        SELECT
+          objektid
+        FROM
+          sagsinfo
+        WHERE
+          sagsid = :new.sagsid
+          AND registreringtil IS NULL
+      );
+    END IF;
   END IF;
-END IF;
-
 END;
 /
 
-CREATE OR REPLACE TRIGGER BID#SAGSEVENTINFO
+
+CREATE OR REPLACE TRIGGER bid#sagseventinfo
 BEFORE INSERT ON sagseventinfo
 FOR EACH ROW
 DECLARE
-cnt number;
+  cnt number;
 BEGIN
-IF :new.REGISTRERINGTIL IS NULL THEN
-  SELECT count(*) INTO cnt
-  FROM sagseventinfo
-  WHERE sagseventid = :new.sagseventid AND registreringtil IS NULL;
+  IF :new.registreringtil IS NULL THEN
+    SELECT
+      count(*) INTO cnt
+    FROM
+      sagseventinfo
+    WHERE
+      sagseventid = :new.sagseventid
+      AND registreringtil IS NULL;
 
-  IF cnt = 1 THEN
-    UPDATE sagseventinfo
-    SET registreringtil = :new.registreringfra
-    WHERE objektid = (
-        SELECT objektid
-        FROM sagseventinfo
-        WHERE sagseventid = :new.sagseventid AND registreringtil IS NULL
-    );
+    IF cnt = 1 THEN
+    UPDATE
+      sagseventinfo
+    SET
+      registreringtil = :new.registreringfra
+    WHERE
+      objektid = (
+        SELECT
+          objektid
+        FROM
+          sagseventinfo
+        WHERE
+          sagseventid = :new.sagseventid
+          AND registreringtil IS NULL
+      );
+    END IF;
   END IF;
-END IF;
-
 END;
 /
 
@@ -1209,7 +1531,7 @@ VALUES (
 INSERT INTO observationstype (
     -- Overordnet beskrivelse
     beskrivelse,
-    OBSERVATIONSTYPEID,
+    observationstypeid,
     observationstype,
     sigtepunkt,
 
@@ -1241,53 +1563,50 @@ VALUES (
     -- Ikke anvendt value6-value15
 );
 
-INSERT INTO observationstype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
+INSERT INTO observationstype (beskrivelse, observationstypeid, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Horisontal retning med uret fra opstilling til sigtepunkt (reduceret til ellipsoiden)', 3 , 'retning', 'true','Retning [m]', 'Varians  retning hidrørende instrument, pr. sats  [rad^2]', 'Samlet centreringsvarians for instrument prisme [m^2]', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO observationstype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
+INSERT INTO observationstype (beskrivelse, observationstypeid, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Horisontal afstand mellem opstilling og sigtepunkt (reduceret til ellipsoiden)', 4 , 'horisontalafstand', 'true','Afstand [m]', 'Afstandsafhængig varians afstandsmåler [m^2/m^2]', 'Samlet varians for centrering af instrument og prisme, samt grundfejl på afstandsmåler [m^2]', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO observationstype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
+INSERT INTO observationstype (beskrivelse, observationstypeid, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Skråafstand mellem opstilling og sigtepunkt', 5 , 'skråafstand', 'true','Afstand [m]', 'Afstandsafhængig varians afstandsmåler pr. måling [m^2/m^2]', 'Samlet varians for centrering af instrument og prisme, samt grundfejl på afstandsmåler pr. måling [m^2]', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO observationstype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
+INSERT INTO observationstype (beskrivelse, observationstypeid, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Zenitvinkel mellem opstilling og sigtepunkt', 6 , 'zenitvinkel', 'true','Zenitvinkel [rad]', 'Instrumenthøjde [m]', 'Højde sigtepunkt [m]', 'Varians zenitvinkel hidrørende instrument, pr. sats  [rad^2]', 'Samlet varians instrumenthøjde/højde sigtepunkt [m^2]', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO observationstype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
+INSERT INTO observationstype (beskrivelse, observationstypeid, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('Vektor der beskriver koordinatforskellen fra punkt 1 til punkt 2 (v2-v1)', 7 , 'vektor', 'true','dx [m]', 'dy [m]', 'dz [m]', 'Afstandsafhængig varians [m^2/m^2]', 'Samlet varians for centrering af antenner [m^2]', 'Varians dx [m^2]', 'Varians dy [m^2]', 'Varians dz [m^2]', 'Covarians dx, dy [m^2]', 'Covarians dx, dz [m^2]', 'Covarians dy, dz [m^2]', NULL, NULL, NULL, NULL);
 
-INSERT INTO observationstype (beskrivelse, OBSERVATIONSTYPEID, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
+INSERT INTO observationstype (beskrivelse, observationstypeid, observationstype, sigtepunkt, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15)
 VALUES ('observation nummer nul, indlagt fra start i observationstabellen, så der kan refereres til den i de mange beregningsevents der fører til population af koordinattabellen', 8 , 'nulobservation', 'false', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 
 -- Oprettelse af eventtyper i FIRE
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når koordinater indsættes efter en beregning.', 'koordinat_beregnet', 1);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når en koordinat nedlægges.', 'koordinat_nedlagt', 2);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Indsættelse af en eller flere observationer.', 'observation_indsat', 3);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når en observation aflyses fordi den er fejlbehæftet.', 'observation_nedlagt', 4);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når der tilføjes Punktinfo til et eller flere punkter.', 'punktinfo_tilføjet', 5);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når Punktinfo fjernes fra et eller flere punkter.', 'punktinfo_fjernet', 6);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når et punkt og tilhørende geometri oprettes.', 'punkt_oprettet', 7);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges når et punkt og tilhørende geometri nedlægges.', 'punkt_nedlagt', 8);
 
-INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
+INSERT INTO eventtype (beskrivelse, event, eventtypeid)
 VALUES ('Bruges til at tilføje fritekst-kommentarer til sagen i tilfælde af at der er behov for at påhæfte sagen yderligere information, som ikke passer i andre hændelser. Bruges fx også til påhæftning af materiale på sagen.', 'kommentar', 9);
-
--- End
-

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -316,33 +316,33 @@ CREATE TABLE sridtype (
 ALTER TABLE
   koordinat
 ADD
-  CONSTRAINT ck_koordinat_transformer248 CHECK (transformeret IN ('true', 'false'));
+  CONSTRAINT koordinat_transformeret_chk CHECK (transformeret IN ('true', 'false'));
 
 ALTER TABLE
   koordinat
 ADD
-  CONSTRAINT ck_koordinat_fejlmeldt CHECK (fejlmeldt IN ('true', 'false'));
+  CONSTRAINT koordinat_fejlmeldt_chk CHECK (fejlmeldt IN ('true', 'false'));
 
 ALTER TABLE
   observationstype
 ADD
-  CONSTRAINT ck_observation_sigtepunkt085 CHECK (sigtepunkt IN ('true', 'false'));
+  CONSTRAINT observation_sigtepunkt_chk CHECK (sigtepunkt IN ('true', 'false'));
 
 ALTER TABLE
   punktinfotype
 ADD
-  CONSTRAINT ck_punktinfoty_anvendelse138 CHECK (anvendelse IN ('FLAG', 'TAL', 'TEKST'));
+  CONSTRAINT punktinfotype_anvendelse_chk CHECK (anvendelse IN ('FLAG', 'TAL', 'TEKST'));
 
 ALTER TABLE
   sagsinfo
 ADD
-  CONSTRAINT ck_sagsinfo_aktiv060 CHECK (aktiv IN ('true', 'false'));
+  CONSTRAINT sagsinfo_aktiv_chk CHECK (aktiv IN ('true', 'false'));
 
 -- Constraints der sikrer at namespacedelen er korrekt i PUNKTINFOTYPE
 ALTER TABLE
   punktinfotype
 ADD
-  CONSTRAINT punktinfotype_con_0001 CHECK (
+  CONSTRAINT punktinfotype_namespace_chk CHECK (
     substr(infotype, 1, instr(infotype, ':') -1) IN ('AFM', 'ATTR', 'IDENT', 'NET', 'REGION', 'SKITSE')
   ) ENABLE VALIDATE;
 
@@ -350,79 +350,80 @@ ADD
 ALTER TABLE
   sridtype
 ADD
-  CONSTRAINT ot_srid_0001 CHECK (
+  CONSTRAINT sridtype_namespace_chk CHECK (
     substr(SRID, 1, instr(SRID, ':') -1) IN ('DK', 'EPSG', 'GL', 'TS')
   ) ENABLE VALIDATE;
 
 
 -- Index sikrer at der kun kan indsættes een række i tabellen
-CREATE UNIQUE INDEX only_one_row ON konfiguration ('1');
+CREATE UNIQUE INDEX konfiguration_only_one_row_idx ON konfiguration ('1');
 
 -- Index der skal sikre at der til samme punkt ikke tilføjes en koordinat
 -- med samme SRIDID, hvis denne ikke er afregistreret
-CREATE UNIQUE INDEX koor_uniq_001 ON koordinat (sridid, punktid, registreringtil);
+CREATE UNIQUE INDEX koordinat_uniq_idx ON koordinat (sridid, punktid, registreringtil);
 
 -- Spatiale index
-CREATE INDEX idx_geometriobjekt_geometri ON geometriobjekt (geometri) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS('layer_gtype=point');
-CREATE INDEX idx_herredsogn_geometri ON herredsogn (geometri) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS ('layer_gtype=polygon');
+CREATE INDEX geometriobjekt_geometri_idx ON geometriobjekt (geometri) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS('layer_gtype=point');
+CREATE INDEX herredsogn_geometri_idx ON herredsogn (geometri) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS ('layer_gtype=polygon');
 
 
 -- Unique index på alle kolonner med ID'er.
-CREATE UNIQUE INDEX id_idx_0001 ON punkt (id);
+CREATE UNIQUE INDEX punkt_id_idx ON punkt (id);
 
 ALTER TABLE
   punkt
 ADD
   (
-    CONSTRAINT punkt_r01 UNIQUE (id) USING INDEX id_idx_0001 ENABLE VALIDATE
+    CONSTRAINT punkt_id_uk UNIQUE (id) USING INDEX punkt_id_idx ENABLE VALIDATE
   );
 
-CREATE UNIQUE INDEX id_idx_0002 ON observation (id);
+CREATE UNIQUE INDEX observation_id_idx ON observation (id);
 
 ALTER TABLE
   observation
 ADD
+
   (
-    CONSTRAINT observation_r02 UNIQUE (id) USING INDEX id_idx_0002 ENABLE VALIDATE
+    CONSTRAINT observation_id_uk UNIQUE (id) USING INDEX observation_id_idx ENABLE VALIDATE
   );
 
-CREATE UNIQUE INDEX sridtype_u01 ON sridtype (sridid);
+CREATE UNIQUE INDEX sridtype_sridid_idx ON sridtype (sridid);
 
 ALTER TABLE
   sridtype
 ADD
-  CONSTRAINT sridtype_u01 UNIQUE (sridid) USING INDEX sridtype_u01 ENABLE VALIDATE;
+  CONSTRAINT sridtype_sridid_uk UNIQUE (sridid) USING INDEX sridtype_sridid_idx ENABLE VALIDATE;
 
-CREATE UNIQUE INDEX eventtype_u01 ON eventtype (eventtypeid);
+CREATE UNIQUE INDEX eventtype_eventtypeid_idx ON eventtype (eventtypeid);
 
 ALTER TABLE
   eventtype
 ADD
-  CONSTRAINT eventtype_u01 UNIQUE (eventtypeid) USING INDEX eventtype_u01 ENABLE VALIDATE;
+  CONSTRAINT eventtype_eventtypeid_uk UNIQUE (eventtypeid) USING INDEX eventtype_eventtypeid_idx ENABLE VALIDATE;
 
-CREATE UNIQUE INDEX punktinfotype_idx_01 ON punktinfotype (infotypeid);
+CREATE UNIQUE INDEX punktinfotype_infotypeid_idx ON punktinfotype (infotypeid);
 
 ALTER TABLE
   punktinfotype
 ADD
-  CONSTRAINT punktinfotype_u01 UNIQUE (infotypeid) USING INDEX punktinfotype_idx_01 ENABLE VALIDATE;
+  CONSTRAINT punktinfotype_infotypeid_uk UNIQUE (infotypeid) USING INDEX punktinfotype_infotypeid_idx ENABLE VALIDATE;
 
-CREATE UNIQUE INDEX observationstype_idx_001 ON observationstype (observationstypeid);
+CREATE UNIQUE INDEX observationstype_obstypeid_idx ON observationstype (observationstypeid);
 
 ALTER TABLE
   observationstype
 ADD
-  CONSTRAINT observationstype_u01 UNIQUE (observationstypeid) USING INDEX observationstype_idx_001 ENABLE VALIDATE;
+  CONSTRAINT observationstype_obstypeid_uk UNIQUE (observationstypeid) USING INDEX observationstype_obstypeid_idx ENABLE VALIDATE;
 
 ALTER TABLE
   sag
 ADD
-  CONSTRAINT sag_u01 UNIQUE (id) ENABLE VALIDATE;
+  CONSTRAINT sag_id_uk UNIQUE (id) ENABLE VALIDATE;
 
 ALTER TABLE
   sagsevent
 ADD
-  CONSTRAINT sagsevent_u01 UNIQUE (id) ENABLE VALIDATE;
+  CONSTRAINT sagsevent_id_uk UNIQUE (id) ENABLE VALIDATE;
 
 
 -- Foreign keys til punktid, sridid og infotypeid, der sikrer at der ikke
@@ -430,84 +431,84 @@ ADD
 ALTER TABLE
   koordinat
 ADD
-  CONSTRAINT koordinat_r01 FOREIGN KEY (sridid) REFERENCES sridtype (sridid) ENABLE VALIDATE;
+  CONSTRAINT koordinat_sridid_fk FOREIGN KEY (sridid) REFERENCES sridtype (sridid) ENABLE VALIDATE;
 
 ALTER TABLE
   koordinat
 ADD
-  CONSTRAINT punktid_con_0001 FOREIGN KEY (punktid) REFERENCES punkt (id) ENABLE VALIDATE;
+  CONSTRAINT koordinat_punktid_fk FOREIGN KEY (punktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
 ALTER TABLE
   observation
 ADD
-  CONSTRAINT Observation_sp_con_0001 FOREIGN KEY (sigtepunktid) REFERENCES punkt (id) ENABLE VALIDATE;
+  CONSTRAINT observation_spunktid_fk FOREIGN KEY (sigtepunktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
 ALTER TABLE
   observation
 ADD
-  CONSTRAINT observation_op1_con_0001 FOREIGN KEY (opstillingspunktid) REFERENCES punkt (id) ENABLE VALIDATE;
+  CONSTRAINT observation_opunktid_fk FOREIGN KEY (opstillingspunktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
 ALTER TABLE
   observation
 ADD
-  CONSTRAINT observation_r01 FOREIGN KEY (observationstypeid) REFERENCES observationstype (observationstypeid) ENABLE VALIDATE;
+  CONSTRAINT observation_obstypeid_fk FOREIGN KEY (observationstypeid) REFERENCES observationstype (observationstypeid) ENABLE VALIDATE;
 
 ALTER TABLE
   punktinfo
 ADD
-  CONSTRAINT punktinfo_con_001 FOREIGN KEY (punktid) REFERENCES punkt (id) ENABLE VALIDATE;
+  CONSTRAINT punktinfo_punktid_fk FOREIGN KEY (punktid) REFERENCES punkt (id) ENABLE VALIDATE;
 
 ALTER TABLE
   punktinfo
 ADD
-  CONSTRAINT punktinfo_r01 FOREIGN KEY (infotypeid) REFERENCES punktinfotype (infotypeid) ENABLE VALIDATE;
+  CONSTRAINT punktinfo_infotypeid_fk FOREIGN KEY (infotypeid) REFERENCES punktinfotype (infotypeid) ENABLE VALIDATE;
 
 ALTER TABLE
   sagsinfo
 ADD
-  CONSTRAINT sagsinfo_r01 FOREIGN KEY (sagsid) REFERENCES sag (id) ENABLE VALIDATE;
+  CONSTRAINT sagsinfo_sagsid_fk FOREIGN KEY (sagsid) REFERENCES sag (id) ENABLE VALIDATE;
 
 ALTER TABLE
   sagsevent
 ADD
-  CONSTRAINT sagsevent_r01 FOREIGN KEY (sagsid) REFERENCES sag (id) ENABLE VALIDATE;
+  CONSTRAINT sagsevent_sagsid_fk FOREIGN KEY (sagsid) REFERENCES sag (id) ENABLE VALIDATE;
 
 ALTER TABLE
   sagsevent
 ADD
-  CONSTRAINT sagsevent_r02 FOREIGN KEY (eventtypeid) REFERENCES eventtype (eventtypeid) ENABLE VALIDATE;
+  CONSTRAINT sagsevent_eventtypeid_fk FOREIGN KEY (eventtypeid) REFERENCES eventtype (eventtypeid) ENABLE VALIDATE;
 
 ALTER TABLE
   sagseventinfo
 ADD
-  CONSTRAINT sagseventinfo_r01 FOREIGN KEY (sagseventid) REFERENCES sagsevent (id) ENABLE VALIDATE;
+  CONSTRAINT sagseventinfo_sagseventid_fk FOREIGN KEY (sagseventid) REFERENCES sagsevent (id) ENABLE VALIDATE;
 
 
 -- Diverse index
 
-CREATE INDEX idx_punktinfo_pid ON punktinfo(punktid);
+CREATE INDEX punktinfo_punktid_idx ON punktinfo(punktid);
 
-CREATE INDEX idx_koordinat_pid ON koordinat(punktid);
+CREATE INDEX koordinat_punktid_idx ON koordinat(punktid);
 
-CREATE INDEX idx_geomobj_pid ON geometriobjekt(punktid);
+CREATE INDEX geometriobjekt_punktid_idx ON geometriobjekt(punktid);
 
-CREATE INDEX idx_observ_opid ON observation(opstillingspunktid);
+CREATE INDEX observation_opunktid_idx ON observation(opstillingspunktid);
 
-CREATE INDEX idx_observ_spid ON observation(sigtepunktid);
+CREATE INDEX observation_spunktid_idx ON observation(sigtepunktid);
 
-CREATE INDEX idx_punktinfotyp_anv ON punktinfotype(anvendelse);
+CREATE INDEX punktinfotype_anvendelse_idx ON punktinfotype(anvendelse);
 
-CREATE INDEX idx_punktinfotyp_typ ON punktinfotype(infotype);
+CREATE INDEX punktinfotype_infotype_idx ON punktinfotype(infotype);
 
 
 --- --  Dette bør lægges på ifm indlæsning fra REFGEO
-CREATE UNIQUE INDEX geomobj_datopid ON geometriobjekt(punktid, registreringfra);
+CREATE UNIQUE INDEX geometriobjekt_unique_idx ON geometriobjekt(punktid, registreringfra);
 
 -- Constraint der tjekker at registreringtil er større end registreringfra
 ALTER TABLE
   beregning
 ADD
-  CONSTRAINT beregning_con_0001 CHECK (
+  CONSTRAINT beregning_registeringtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -520,7 +521,7 @@ ADD
 ALTER TABLE
   geometriobjekt
 ADD
-  CONSTRAINT geometriobjekt_con_0001 CHECK (
+  CONSTRAINT geometriobjekt_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -533,7 +534,7 @@ ADD
 ALTER TABLE
   koordinat
 ADD
-  CONSTRAINT koordinat_con_0001 CHECK (
+  CONSTRAINT koordinat_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -546,7 +547,7 @@ ADD
 ALTER TABLE
   observation
 ADD
-  CONSTRAINT observation_con_0001 CHECK (
+  CONSTRAINT observation_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -559,7 +560,7 @@ ADD
 ALTER TABLE
   punkt
 ADD
-  CONSTRAINT punkt_con_0001 CHECK (
+  CONSTRAINT punkt_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -572,7 +573,7 @@ ADD
 ALTER TABLE
   punktinfo
 ADD
-  CONSTRAINT punktinfo_con_0001 CHECK (
+  CONSTRAINT punktinfo_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -585,7 +586,7 @@ ADD
 ALTER TABLE
   sagsinfo
 ADD
-  CONSTRAINT sagsinfo_con_0001 CHECK (
+  CONSTRAINT sagsinfo_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -598,7 +599,7 @@ ADD
 ALTER TABLE
   sagseventinfo
 ADD
-  CONSTRAINT sagseventinfo_con_0001 CHECK (
+  CONSTRAINT sagseventinfo_regtil_ck CHECK (
     nvl(
       registreringtil,
       to_timestamp_tz(
@@ -782,7 +783,7 @@ COMMENT ON COLUMN sridtype.z IS 'Beskrivelse af z-koordinatens indhold.';
 -----------------------------------------------------------------------------------------
 
 -- Triggere der sikrer at kun registreringtil kan opdateres i en tabel
-CREATE OR REPLACE TRIGGER aud#beregning
+CREATE OR REPLACE TRIGGER beregning_au_trg
 AFTER UPDATE ON beregning FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
@@ -800,7 +801,7 @@ END;
 /
 
 
-CREATE OR REPLACE TRIGGER aud#geometriobjekt
+CREATE OR REPLACE TRIGGER geometriobjekt_au_trg
 AFTER UPDATE ON geometriobjekt FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
@@ -821,7 +822,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE TRIGGER aud#koordinat
+CREATE OR REPLACE TRIGGER koordinat_au_trg
 AFTER UPDATE ON koordinat
 FOR EACH ROW
 BEGIN
@@ -884,7 +885,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE TRIGGER aud#observation
+CREATE OR REPLACE TRIGGER observation_au_trg
 AFTER UPDATE ON observation
 FOR EACH ROW
 BEGIN
@@ -984,7 +985,7 @@ END;
 
 -- Trigger der sikrer at indeholdet i tabellen KOORDINAT matcher hvad der er
 -- specificeret omkring SRID i SRIDTYPE tabellen
-CREATE OR REPLACE TRIGGER aiu#koordinat
+CREATE OR REPLACE TRIGGER koordinat_aiu_trg
 AFTER INSERT OR UPDATE ON koordinat
 FOR EACH ROW
 DECLARE
@@ -1013,7 +1014,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE TRIGGER aud#punkt
+CREATE OR REPLACE TRIGGER punkt_au_trg
 AFTER UPDATE ON punkt
 FOR EACH ROW
 BEGIN
@@ -1036,7 +1037,7 @@ END;
 /
 
 
-CREATE OR REPLACE TRIGGER aud#sag
+CREATE OR REPLACE TRIGGER sag_bu_trg
 BEFORE UPDATE ON sag
 FOR EACH ROW
 BEGIN
@@ -1055,7 +1056,7 @@ END;
 /
 
 
-CREATE OR REPLACE TRIGGER aud#sagsevent
+CREATE OR REPLACE TRIGGER sagsevent_au_trg
 AFTER UPDATE ON sagsevent
 FOR EACH ROW
 BEGIN
@@ -1080,7 +1081,7 @@ end;
 
 
 
-CREATE OR REPLACE TRIGGER aud#sagseventinfo
+CREATE OR REPLACE TRIGGER sagseventinfo_bu_trg
 BEFORE UPDATE ON sagseventinfo
 FOR EACH ROW
 BEGIN
@@ -1103,7 +1104,7 @@ END;
 /
 
 
-CREATE OR REPLACE TRIGGER aud#sagsinfo
+CREATE OR REPLACE TRIGGER sagsinfo_bu_trg
 BEFORE UPDATE ON sagsinfo
 FOR EACH ROW
 BEGIN
@@ -1139,7 +1140,7 @@ END;
 
 
 -- Trigger der sikrer at sageevents kun knyttes til en aktiv sag
-CREATE OR REPLACE TRIGGER aid#sagsevent
+CREATE OR REPLACE TRIGGER sagsevent_ai_trg
 AFTER INSERT ON sagsevent
 FOR EACH ROW
 DECLARE
@@ -1167,7 +1168,7 @@ END;
 
 -- Trigger der skal sikre at inholdet i Observation-tabellen matcher hvad
 -- der er defineret observationstype-tabellen
-CREATE OR REPLACE TRIGGER aid#observation
+CREATE OR REPLACE TRIGGER observation_aiu_trg
 AFTER INSERT OR UPDATE ON observation
 FOR EACH ROW
 DECLARE
@@ -1265,7 +1266,7 @@ END;
 
 -- Sikrer at infotype i PUNKTINFO eksisterer i PUNKTINFOTYPE, og at data i PUNKTINFO matcher definition i PUNKTINFOTYPE
 -- og at tidligere version af punktinfo afregistreres korrekt ved indsættelse af ny
-CREATE OR REPLACE TRIGGER punktinfo_type_valid_trg
+CREATE OR REPLACE TRIGGER punktinfo_biu_trg
 BEFORE INSERT OR UPDATE ON punktinfo
 FOR EACH ROW
 DECLARE
@@ -1327,7 +1328,7 @@ END;
 /
 
 
-CREATE OR REPLACE TRIGGER bid#punkt
+CREATE OR REPLACE TRIGGER punkt_bi_trg
 BEFORE INSERT ON punkt
 FOR EACH ROW
 DECLARE
@@ -1348,7 +1349,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE TRIGGER bid#koordinat
+CREATE OR REPLACE TRIGGER koordinat_bi_trg
 BEFORE INSERT ON koordinat
 FOR EACH ROW
 DECLARE
@@ -1403,7 +1404,7 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE TRIGGER bid#sagsinfo
+CREATE OR REPLACE TRIGGER sagsinfo_bi_trg
 BEFORE INSERT ON sagsinfo
 FOR EACH ROW
 DECLARE
@@ -1439,7 +1440,7 @@ END;
 /
 
 
-CREATE OR REPLACE TRIGGER bid#sagseventinfo
+CREATE OR REPLACE TRIGGER sagseventinfo_bi_trg
 BEFORE INSERT ON sagseventinfo
 FOR EACH ROW
 DECLARE

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1292,8 +1292,16 @@ BEGIN
     RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tal skal være NULL ved anvendelsestypen "TEKST"');
   END IF;
 
+  IF this_andv = 'TEKST' AND :new.tekst IS NULL THEN
+    RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tekst må ikke være NULL ved anvendelsestypen "TEKST"');
+  END IF;
+
   IF this_andv = 'TAL' AND :new.tekst IS NOT NULL THEN
     RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tekst skal være NULL ved anvendelsestypen "TAL"');
+  END IF;
+
+  IF this_andv = 'TAL' AND :new.tal IS NULL THEN
+    RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tal må ikke være NULL ved anvendelsestypen "TAL"');
   END IF;
 
   -- afregistrer forrige version af punktinfo når nyt indsættes

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -787,15 +787,15 @@ CREATE OR REPLACE TRIGGER beregning_au_trg
 AFTER UPDATE ON beregning FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'beregning.objektid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'beregning.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.sagseventfraid != :old.sagseventfraid THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'beregning.sagseventfraid må ikke opdateres ');
   END IF;
 END;
 /
@@ -805,19 +805,19 @@ CREATE OR REPLACE TRIGGER geometriobjekt_au_trg
 AFTER UPDATE ON geometriobjekt FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'geometriobjekt.objektid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'geometriobjekt.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.sagseventfraid != :old.sagseventfraid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'geometriobjket.sagseventfraid  må ikke opdateres ');
   END IF;
 
   IF :new.punktid != :old.punktid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'geometriobjekt.punktid må ikke opdateres ');
   END IF;
 END;
 /
@@ -827,59 +827,59 @@ AFTER UPDATE ON koordinat
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.objektid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.sridid != :old.sridid THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.sridid må ikke opdateres ');
   END IF;
 
   IF :new.sx != :old.sx THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.sx må ikke opdateres ');
   END IF;
 
   IF :new.sy != :old.sy THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.sy må ikke opdateres ');
   END IF;
 
   IF :new.sz != :old.sz THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.sz må ikke opdateres ');
   END IF;
 
   IF :new.t != :old.t THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.t må ikke opdateres ');
   END IF;
 
   IF :new.transformeret != :old.transformeret THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.transformeret må ikke opdateres ');
   END IF;
 
   IF :new.x != :old.x THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.x må ikke opdateres ');
   END IF;
 
   IF :new.y != :old.y THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.y må ikke opdateres ');
   END IF;
 
   IF :new.z != :old.z THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.z må ikke opdateres ');
   END IF;
 
   IF :new.sagseventfraid != :old.sagseventfraid THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.sagseventfraid må ikke opdateres ');
   END IF;
 
   IF :new.punktid != :old.punktid THEN
-    RAISE_APPLICATION_ERROR(-20000, 'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000, 'koordinat.punktid må ikke opdateres ');
   END IF;
 
   IF :new.fejlmeldt != :old.fejlmeldt AND :new.registreringtil IS NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Registreringtil skal sættes når en koordinat fejlmeldes');
+    RAISE_APPLICATION_ERROR(-20001, 'Registreringtil skal sættes når en koordinat fejlmeldes');
   END IF;
 
 END;
@@ -890,95 +890,95 @@ AFTER UPDATE ON observation
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.objektid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.antal != :old.antal THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.antal må ikke opdateres ');
   END IF;
 
   IF :new.gruppe != :old.gruppe THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.gruppe må ikke opdateres ');
   END IF;
 
   IF :new.observationstypeid != :old.observationstypeid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.observationstypeid må ikke opdateres ');
   END IF;
 
   IF :new.value1 != :old.value1 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value1 må ikke opdateres ');
   END IF;
 
   IF :new.value2 != :old.value2 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value2 må ikke opdateres ');
   END IF;
 
   IF :new.value3 != :old.value3 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value3 må ikke opdateres ');
   END IF;
 
   IF :new.value4 != :old.value4 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value4 må ikke opdateres ');
   END IF;
 
   IF :new.value5 != :old.value5 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value5 må ikke opdateres ');
   END IF;
 
   IF :new.value6 != :old.value6 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value6 må ikke opdateres ');
   END IF;
 
   IF :new.value7 != :old.value7 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value7 må ikke opdateres ');
   END IF;
 
   IF :new.value8 != :old.value8 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value8 må ikke opdateres ');
   END IF;
 
   IF :new.value9 != :old.value9 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value9 må ikke opdateres ');
   END IF;
 
   IF :new.value10 != :old.value10 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value10 må ikke opdateres ');
   END IF;
 
   IF :new.value11 != :old.value11 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value11 må ikke opdateres ');
   END IF;
 
   IF :new.value12 != :old.value12 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value12 må ikke opdateres ');
   END IF;
 
   IF :new.value13 != :old.value13 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value13 må ikke opdateres ');
   END IF;
 
   IF :new.value14 != :old.value14 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value14 må ikke opdateres ');
   END IF;
 
   IF :new.value15 != :old.value15 THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.value15 må ikke opdateres ');
   END IF;
 
   IF :new.sagseventfraid != :old.sagseventfraid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.sagseventfraid må ikke opdateres ');
   END IF;
 
   IF :new.opstillingspunktid != :old.opstillingspunktid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.opstillingspunktid må ikke opdateres ');
   END IF;
 
   IF :new.sigtepunktid != :old.sigtepunktid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'observation.sigtepunktid må ikke opdateres ');
   END IF;
 END;
 /
@@ -1001,15 +1001,15 @@ BEGIN
     a.sridid = :new.sridid;
 
   IF (:new.x IS NULL OR :new.sx IS NULL) AND valX IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Hverken X eller SX må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Hverken X eller SX må ikke være NULL');
   END IF;
 
   IF (:new.y IS NULL OR :new.sy IS NULL) AND valY IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Hverken Y eller SY må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Hverken Y eller SY må ikke være NULL');
   END IF;
 
   IF (:new.Z IS NULL OR :new.SZ IS NULL) AND valZ IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Hverken Z eller SZ må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Hverken Z eller SZ må ikke være NULL');
   END IF;
 END;
 /
@@ -1019,19 +1019,19 @@ AFTER UPDATE ON punkt
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'punkt.objektid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'punkt.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.id != :old.id THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'punkt.id må ikke opdateres ');
   END IF;
 
   IF :new.sagseventfraid != :old.sagseventfraid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'punkt.sagseventfraid må ikke opdateres ');
   END IF;
 END;
 /
@@ -1042,15 +1042,15 @@ BEFORE UPDATE ON sag
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sag.objektid må ikke opdateres ');
   END IF;
 
   IF :new.id != :old.id THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sag.id må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sag.registreringfra må ikke opdateres ');
   END IF;
 END;
 /
@@ -1061,19 +1061,19 @@ AFTER UPDATE ON sagsevent
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(a) ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsevent.objektid må ikke opdateres ');
   END IF;
 
   IF :new.id != :old.id THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(b) ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsevent.id må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(c) ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsevent.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.sagsid != :old.sagsid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column(d) ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsevent.sagsid må ikke opdateres ');
   END IF;
 
 end;
@@ -1086,19 +1086,19 @@ BEFORE UPDATE ON sagseventinfo
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagseventinfo.objektid må ikke opdateres ');
   END IF;
 
   IF :new.sagseventid != :old.sagseventid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagseventinfo.sagseventid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagseventinfo.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.beskrivelse != :old.beskrivelse THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagseventinfo.beskrivelse må ikke opdateres ');
   END IF;
 END;
 /
@@ -1109,31 +1109,31 @@ BEFORE UPDATE ON sagsinfo
 FOR EACH ROW
 BEGIN
   IF :new.objektid != :old.objektid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.objektid må ikke opdateres ');
   END IF;
 
   IF :new.sagsid != :old.sagsid THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.sagsid må ikke opdateres ');
   END IF;
 
   IF :new.registreringfra != :old.registreringfra THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.registreringfra må ikke opdateres ');
   END IF;
 
   IF :new.aktiv != :old.aktiv THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.aktiv må ikke opdateres ');
   END IF;
 
   IF :new.journalnummer != :old.journalnummer THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.journalnummer må ikke opdateres ');
   END IF;
 
   IF :new.behandler != :old.behandler THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.behandler må ikke opdateres ');
   END IF;
 
   IF :new.beskrivelse != :old.beskrivelse THEN
-    RAISE_APPLICATION_ERROR(-20000,'You cannot update this column ');
+    RAISE_APPLICATION_ERROR(-20000,'sagsinfo.beskrivelse må ikke opdateres ');
   END IF;
 END;
 /
@@ -1160,7 +1160,7 @@ BEGIN
   END;
 
   IF cnt = 0 THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Ingen aktiv sag fundet paa sagsid ' || :new.sagsid);
+    RAISE_APPLICATION_ERROR(-20003, 'Ingen aktiv sag fundet paa sagsid ' || :new.sagsid);
   END IF;
 END;
 /
@@ -1202,63 +1202,63 @@ BEGIN
     a.observationstypeid = :new.observationstypeid;
 
   IF :new.value1 IS NULL AND val1 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value1 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value1 må ikke være NULL');
   END IF;
 
   IF :new.value2 IS NULL AND val2 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value2 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value2 må ikke være NULL');
   END IF;
 
   IF :new.value3 IS NULL AND val3 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value3 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value3 må ikke være NULL');
   END IF;
 
   IF :new.value4 IS NULL AND val4 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value4 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value4 må ikke være NULL');
   END IF;
 
   IF :new.value5 IS NULL AND val5 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value5 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value5 må ikke være NULL');
   END IF;
 
   IF :new.value6 IS NULL AND val6 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value6 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value6 må ikke være NULL');
   END IF;
 
   IF :new.value7 IS NULL AND val7 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value7 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value7 må ikke være NULL');
   END IF;
 
   IF :new.value8 IS NULL AND val8 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value8 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value8 må ikke være NULL');
   END IF;
 
   IF :new.value9 IS NULL AND val9 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value9 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value9 må ikke være NULL');
   END IF;
 
   IF :new.value10 IS NULL AND val10 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value10 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value10 må ikke være NULL');
   END IF;
 
   IF :new.value11 IS NULL AND val11 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value11 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value11 må ikke være NULL');
   END IF;
 
   IF :new.value12 IS NULL AND val12 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value12 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value12 må ikke være NULL');
   END IF;
 
   IF :new.value13 IS NULL AND val13 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value13 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value13 må ikke være NULL');
   END IF;
 
   IF :new.value14 IS NULL AND val14 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value14 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value14 må ikke være NULL');
   END IF;
 
   IF :new.value15 IS NULL AND val15 IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Value15 må ikke være NULL');
+    RAISE_APPLICATION_ERROR(-20002, 'Value15 må ikke være NULL');
   END IF;
 END;
 /
@@ -1281,19 +1281,19 @@ BEGIN
     WHERE
       infotypeid = :new.infotypeid;
   EXCEPTION
-    WHEN no_data_found THEN RAISE_APPLICATION_ERROR(-20000, 'No infotype found(!)');
+    WHEN no_data_found THEN RAISE_APPLICATION_ERROR(-20004, 'Punktinfotype ikke fundet!');
   END;
 
   IF this_andv = 'FLAG' AND (:new.tekst IS NOT NULL OR :new.tal IS NOT NULL) THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Incorrect data (A)(!)');
+    RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tekst og punktinfo.tal skal være NULL ved anvendelsestypen "FLAG"');
   END IF;
 
   IF this_andv = 'TEKST' AND :new.tal IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Incorrect data (B)(!)');
+    RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tal skal være NULL ved anvendelsestypen "TEKST"');
   END IF;
 
   IF this_andv = 'TAL' AND :new.tekst IS NOT NULL THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Incorrect data (C)(!)');
+    RAISE_APPLICATION_ERROR(-20005, 'punktinfo.tekst skal være NULL ved anvendelsestypen "TAL"');
   END IF;
 
   -- afregistrer forrige version af punktinfo når nyt indsættes
@@ -1343,7 +1343,7 @@ BEGIN
       registreringtil = :new.registreringfra;
 
     IF cnt1 = 0 THEN
-      RAISE_APPLICATION_ERROR(-20000,'No parent record found (!) ');
+      RAISE_APPLICATION_ERROR(-20006, 'Manglende forudgående punkt');
     END IF;
   END IF;
 END;
@@ -1364,7 +1364,7 @@ BEGIN
       registreringtil = :new.registreringfra;
 
     if cnt = 0 THEN
-      RAISE_APPLICATION_ERROR(-20000,'No parent record found (!) ');
+      RAISE_APPLICATION_ERROR(-20006,'Manglende forudgående koordinat');
     END IF;
   END IF;
 
@@ -1399,7 +1399,7 @@ BEGIN
   END IF;
 
   IF :new.fejlmeldt = 'true' THEN
-    RAISE_APPLICATION_ERROR(-20000, 'Indsættelse af fejlmeldt koordinat ikke tilladt');
+    RAISE_APPLICATION_ERROR(-20007, 'Indsættelse af fejlmeldt koordinat ikke tilladt');
   END IF;
 END;
 /

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1,10 +1,16 @@
-CREATE TABLE BEREGNING (
+-----------------------------------------------------------------------------------------
+--                                TABLE CREATION
+-----------------------------------------------------------------------------------------
 
-   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
-   REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
-   REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
-   SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
-   SAGSEVENTTILID VARCHAR2(36)
+CREATE TABLE BEREGNING (
+  OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (
+    START WITH
+      1 INCREMENT BY 1 ORDER NOCACHE
+  ) PRIMARY KEY,
+  REGISTRERINGFRA TIMESTAMP WITH TIME ZONE NOT NULL,
+  REGISTRERINGTIL TIMESTAMP WITH TIME ZONE,
+  SAGSEVENTFRAID VARCHAR2(36) NOT NULL,
+  SAGSEVENTTILID VARCHAR2(36)
 );
 
 CREATE TABLE BEREGNING_KOORDINAT (
@@ -39,12 +45,15 @@ CREATE TABLE GEOMETRIOBJEKT (
    GEOMETRI SDO_GEOMETRY NOT NULL,
    PUNKTID VARCHAR2(36) NOT NULL
 );
+INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) VALUES ('GEOMETRIOBJEKT', 'GEOMETRI', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005), MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)), 4326);
 
 CREATE TABLE HERREDSOGN (
   OBJEKTID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1 ORDER NOCACHE) PRIMARY KEY,
   KODE VARCHAR2(6) NOT NULL,
   GEOMETRI SDO_GEOMETRY NOT NULL
 );
+INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) VALUES ('HERREDSOGN', 'GEOMETRI', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005), MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)), 4326);
+
 
 CREATE TABLE KOORDINAT (
 
@@ -227,6 +236,10 @@ CREATE TABLE SRIDTYPE (
    BESKRIVELSE VARCHAR2(4000) NOT NULL
 );
 
+-----------------------------------------------------------------------------------------
+--                                  CONSTRAINTS & INDEX
+-----------------------------------------------------------------------------------------
+
 
 ALTER TABLE KOORDINAT ADD CONSTRAINT CK_KOORDINAT_TRANSFORMER248 CHECK (TRANSFORMERET IN ('true', 'false'));
 ALTER TABLE KOORDINAT ADD CONSTRAINT CK_KOORDINAT_FEJLMELDT CHECK (FEJLMELDT IN ('true', 'false'));
@@ -234,160 +247,12 @@ ALTER TABLE OBSERVATIONSTYPE ADD CONSTRAINT CK_OBSERVATION_SIGTEPUNKT085 CHECK (
 ALTER TABLE PUNKTINFOTYPE ADD CONSTRAINT CK_PUNKTINFOTY_ANVENDELSE138 CHECK (ANVENDELSE IN ('FLAG', 'TAL', 'TEKST'));
 ALTER TABLE SAGSINFO ADD CONSTRAINT CK_SAGSINFO_AKTIV060 CHECK (AKTIV IN ('true', 'false'));
 
-INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) VALUES ('GEOMETRIOBJEKT', 'GEOMETRI', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005), MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)), 4326);
-INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) VALUES ('HERREDSOGN', 'GEOMETRI', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005), MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)), 4326);
+
 
 CREATE INDEX IDX_GEOMETRIOBJEKT_GEOMETRI ON GEOMETRIOBJEKT (GEOMETRI) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS('layer_gtype=point');
 CREATE INDEX IDX_HERREDSOGN_GEOMETRI ON HERREDSOGN (GEOMETRI) INDEXTYPE IS MDSYS.SPATIAL_INDEX PARAMETERS ('layer_gtype=polygon');
 
-COMMENT ON TABLE BEREGNING IS 'Sammenknytter beregnede koordinater med de anvendte observationer.';
-COMMENT ON COLUMN BEREGNING.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN BEREGNING.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN BEREGNING.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN BEREGNING.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN BEREGNING_KOORDINAT.KOORDINATOBJEKTID IS 'Udpegning af de koordinater der er indgået i en beregning.';
-COMMENT ON COLUMN BEREGNING_OBSERVATION.OBSERVATIONOBJEKTID IS 'Udpegning af de observationer der er brugt i en beregning.';
-COMMENT ON TABLE EVENTTYPE IS 'Objekt til at holde en liste over lovlige typer af events i fikspunktsforvaltningssystemet, samt en beskrivelse hvad eventtypen dækker over.';
-COMMENT ON COLUMN EVENTTYPE.BESKRIVELSE IS 'Kort beskrivelse af en eventtype.';
-COMMENT ON COLUMN EVENTTYPE.EVENT IS 'Navngivning af en eventtype.';
-COMMENT ON COLUMN EVENTTYPE.EVENTTYPEID IS 'Identifikation af typen af en sagsevent.';
-COMMENT ON TABLE GEOMETRIOBJEKT IS 'Objekt indeholdende et punkts placeringsgeometri.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.GEOMETRI IS 'Geometri til brug for visning i f.eks et GIS system.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.PUNKTID IS 'Punkt som har en placeringsgeometri tilknyttet.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN GEOMETRIOBJEKT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN GEOMETRIOBJEKT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON TABLE KOORDINAT IS 'Generisk 4D koordinat.';
-COMMENT ON COLUMN KOORDINAT.PUNKTID IS 'Punkt som koordinaten hører til.';
-COMMENT ON COLUMN KOORDINAT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN KOORDINAT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN KOORDINAT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN KOORDINAT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN KOORDINAT.SRIDID IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
-COMMENT ON COLUMN KOORDINAT.SX IS 'A posteriori spredning på førstekoordinaten.';
-COMMENT ON COLUMN KOORDINAT.SY IS 'A posteriori spredning på andenkoordinaten.';
-COMMENT ON COLUMN KOORDINAT.SZ IS 'A posteriori spredning på tredjekoordinaten.';
-COMMENT ON COLUMN KOORDINAT.T IS 'Observationstidspunktet.';
-COMMENT ON COLUMN KOORDINAT.FEJLMELDT IS 'Markering af at en koordinat er udgået fordi den er fejlbehæftet';
-COMMENT ON COLUMN KOORDINAT.TRANSFORMERET IS 'Angivelse om positionen er målt, eller transformeret fra et andet koordinatsystem';
-COMMENT ON COLUMN KOORDINAT.ARTSKODE IS 'Fra REFGEO. Værdierne skal forstås som følger:
 
- artskode = 1 control point in fundamental network, first order.
- artskode = 2 control point in superior plane network.
- artskode = 2 control point in superior height network.
- artskode = 3 control point in network of high quality.
- artskode = 4 control point in network of lower or unknown quality.
- artskode = 5 coordinate computed on just a few measurements.
- artskode = 6 coordinate transformed from local or an not valid coordinate system.
- artskode = 7 coordinate computed on an not valid coordinate system, or system of unknown origin.
- artskode = 8 coordinate computed on few measurements, and on an not valid coordinate system.
- artskode = 9 location coordinate or location height.
-
- Artskode er kun tilgængelig for koordinater der stammer fra REFGEO.';
-COMMENT ON COLUMN KOORDINAT.X IS 'Førstekoordinat.';
-COMMENT ON COLUMN KOORDINAT.Y IS 'Andenkoordinat.';
-COMMENT ON COLUMN KOORDINAT.Z IS 'Tredjekoordinat.';
-COMMENT ON TABLE OBSERVATION IS 'Generisk observationsobjekt indeholdende informationer om en observation.';
-COMMENT ON COLUMN OBSERVATION.ANTAL IS 'Antal gentagne observationer hvoraf en middelobservationen er fremkommet.';
-COMMENT ON COLUMN OBSERVATION.GRUPPE IS 'ID der angiver observationsgruppen for en observation der indgår i en gruppe.';
-COMMENT ON COLUMN OBSERVATION.OBSERVATIONSTIDSPUNKT IS 'Tidspunktet hvor observationen er foretaget';
-COMMENT ON COLUMN OBSERVATION.OBSERVATIONSTYPEID IS 'Identifikation af en observations type.';
-COMMENT ON COLUMN OBSERVATION.OPSTILLINGSPUNKTID IS 'Udpegning af det punkt der er anvendt ved opstilling ved en observation.';
-COMMENT ON COLUMN OBSERVATION.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN OBSERVATION.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN OBSERVATION.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN OBSERVATION.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN OBSERVATION.SIGTEPUNKTID IS 'Udpegning af punkt der er sigtet til ved en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE1 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE10 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE11 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE12 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE13 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE14 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE15 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE2 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE3 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE4 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE5 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE6 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE7 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE8 IS 'En værdi for en observation.';
-COMMENT ON COLUMN OBSERVATION.VALUE9 IS 'En værdi for en observation.';
-COMMENT ON TABLE OBSERVATIONSTYPE IS 'Objekttype til beskrivelse af hvorledes en Observation skal læses, ud fra typen af observation.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.BESKRIVELSE IS 'Overordnet beskrivelse af denne observationstype.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.OBSERVATIONSTYPE IS 'Kortnavn for observationstypen, fx dH';
-COMMENT ON COLUMN OBSERVATIONSTYPE.OBSERVATIONSTYPEID IS 'Identifikation af observationenst type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.SIGTEPUNKT IS 'Indikator for om Sigtepunkt anvendes for denne observationstype.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE1 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE10 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE11 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE12 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE13 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE14 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE15 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE2 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE3 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE4 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE5 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE6 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE7 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE8 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE9 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
-COMMENT ON TABLE PUNKT IS 'Abstrakt repræsentation af et fysisk punkt. Knytter alle punktinformationer sammen.';
-COMMENT ON COLUMN PUNKT.ID IS 'Persistent unik nøgle.';
-COMMENT ON COLUMN PUNKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN PUNKT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN PUNKT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN PUNKT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON TABLE PUNKTINFO IS 'Generisk information om et punkt.';
-COMMENT ON COLUMN PUNKTINFO.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
-COMMENT ON COLUMN PUNKTINFO.PUNKTID IS 'Punktet som punktinfo er holder information om.';
-COMMENT ON COLUMN PUNKTINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN PUNKTINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN PUNKTINFO.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
-COMMENT ON COLUMN PUNKTINFO.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
-COMMENT ON COLUMN PUNKTINFO.TAL IS 'Værdien for numeriske informationselementer';
-COMMENT ON COLUMN PUNKTINFO.TEKST IS 'Værdien for tekstinformationselementer';
-COMMENT ON TABLE PUNKTINFOTYPE IS 'Udfaldsrum for punktinforobjekter med definition af hvordan PunktInfo skal læses og beskrivelse af typen af punktinfo.';
-COMMENT ON COLUMN PUNKTINFOTYPE.ANVENDELSE IS 'Er det reelTal, tekst, eller ingen af disse, der angiver værdien';
-COMMENT ON COLUMN PUNKTINFOTYPE.BESKRIVELSE IS 'Beskrivelse af denne informationstypes art.';
-COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPE IS 'Arten af dette informationselement';
-COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
-COMMENT ON TABLE SAG IS 'Samling af administrativt relaterede sagshændelser.';
-COMMENT ON COLUMN SAG.ID IS 'Persistent unik nøgle.';
-COMMENT ON COLUMN SAG.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON TABLE SAGSEVENT IS 'Udvikling i sag som kan, men ikke behøver, medføre opdateringer af fikspunktregisterobjekter.';
-COMMENT ON COLUMN SAGSEVENT.EVENTTYPEID IS 'Identifikation af typen af en sagsevent.';
-COMMENT ON COLUMN SAGSEVENT.ID IS 'Persistent unik nøgle.';
-COMMENT ON COLUMN SAGSEVENT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN SAGSEVENT.SAGSID IS 'Udpegning af den sag i fikspunktsforvalningssystemet som en event er foretaget i.';
-COMMENT ON TABLE SAGSEVENTINFO IS 'Informationer der knytter sig til en et sagsevent.';
-COMMENT ON COLUMN SAGSEVENTINFO.BESKRIVELSE IS 'Specifik beskrivelse af den aktuelle fremdrift.';
-COMMENT ON COLUMN SAGSEVENTINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN SAGSEVENTINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN SAGSEVENTINFO.SAGSEVENTID IS 'Den sagsevent som sagseventinfo har information om.';
-COMMENT ON COLUMN SAGSEVENTINFO_HTML.HTML IS 'Generisk operatørlæsbart orienterende rapportmateriale.';
-COMMENT ON TABLE SAGSEVENTINFO_MATERIALE IS 'Eksternt placeret materiale knyttet til en event';
-COMMENT ON COLUMN SAGSEVENTINFO_MATERIALE.MD5SUM IS 'Sum brugt til at kontrollere materialets integritet.';
-COMMENT ON COLUMN SAGSEVENTINFO_MATERIALE.STI IS 'Placering af materialet.';
-COMMENT ON TABLE SAGSINFO IS 'Samling af administrativt relaterede sagshændelser.';
-COMMENT ON COLUMN SAGSINFO.AKTIV IS 'Markerer om sagen er åben eller lukket.';
-COMMENT ON COLUMN SAGSINFO.BEHANDLER IS 'Angivelse af en sagsbehandler.';
-COMMENT ON COLUMN SAGSINFO.BESKRIVELSE IS 'Kort beskrivelse af en fikspunktssag.';
-COMMENT ON COLUMN SAGSINFO.JOURNALNUMMER IS 'Sagsmappeidentifikation i opmålings- og beregningssagsregistret.';
-COMMENT ON COLUMN SAGSINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
-COMMENT ON COLUMN SAGSINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
-COMMENT ON COLUMN SAGSINFO.SAGSID IS 'Den sag som sagsinfo holder information for.';
-COMMENT ON TABLE SRIDTYPE IS 'Udfaldsrum for SRID-koordinatbeskrivelser.';
-COMMENT ON COLUMN SRIDTYPE.BESKRIVELSE IS 'Generel beskrivelse af systemet.';
-COMMENT ON COLUMN SRIDTYPE.SRID IS 'Den egentlige referencesystemindikator.';
-COMMENT ON COLUMN SRIDTYPE.SRIDID IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
-COMMENT ON COLUMN SRIDTYPE.X IS 'Beskrivelse af x-koordinatens indhold';
-COMMENT ON COLUMN SRIDTYPE.Y IS 'Beskrivelse af y-koordinatens indhold.';
-COMMENT ON COLUMN SRIDTYPE.Z IS 'Beskrivelse af z-koordinatens indhold.';
-
--- Constraints og triggers ikke defineret i modellen
 -- Constraint der tjekker at PUNKTID eksisterer i PUNKT tabellen inden en række
 -- sættes ind i KOORDINAT-, OBSERVATION- og PUNKTINFO-tabellen
 CREATE UNIQUE INDEX ID_IDX_0001 ON PUNKT (ID);
@@ -584,6 +449,163 @@ FOREIGN KEY (SAGSEVENTID)
 REFERENCES SAGSEVENT (ID)
 ENABLE VALIDATE);
 
+
+-----------------------------------------------------------------------------------------
+--                                     COMMENTS
+-----------------------------------------------------------------------------------------
+
+
+COMMENT ON TABLE BEREGNING IS 'Sammenknytter beregnede koordinater med de anvendte observationer.';
+COMMENT ON COLUMN BEREGNING.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN BEREGNING.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN BEREGNING.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN BEREGNING.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN BEREGNING_KOORDINAT.KOORDINATOBJEKTID IS 'Udpegning af de koordinater der er indgået i en beregning.';
+COMMENT ON COLUMN BEREGNING_OBSERVATION.OBSERVATIONOBJEKTID IS 'Udpegning af de observationer der er brugt i en beregning.';
+COMMENT ON TABLE EVENTTYPE IS 'Objekt til at holde en liste over lovlige typer af events i fikspunktsforvaltningssystemet, samt en beskrivelse hvad eventtypen dækker over.';
+COMMENT ON COLUMN EVENTTYPE.BESKRIVELSE IS 'Kort beskrivelse af en eventtype.';
+COMMENT ON COLUMN EVENTTYPE.EVENT IS 'Navngivning af en eventtype.';
+COMMENT ON COLUMN EVENTTYPE.EVENTTYPEID IS 'Identifikation af typen af en sagsevent.';
+COMMENT ON TABLE GEOMETRIOBJEKT IS 'Objekt indeholdende et punkts placeringsgeometri.';
+COMMENT ON COLUMN GEOMETRIOBJEKT.GEOMETRI IS 'Geometri til brug for visning i f.eks et GIS system.';
+COMMENT ON COLUMN GEOMETRIOBJEKT.PUNKTID IS 'Punkt som har en placeringsgeometri tilknyttet.';
+COMMENT ON COLUMN GEOMETRIOBJEKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN GEOMETRIOBJEKT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN GEOMETRIOBJEKT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN GEOMETRIOBJEKT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON TABLE KOORDINAT IS 'Generisk 4D koordinat.';
+COMMENT ON COLUMN KOORDINAT.PUNKTID IS 'Punkt som koordinaten hører til.';
+COMMENT ON COLUMN KOORDINAT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN KOORDINAT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN KOORDINAT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN KOORDINAT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN KOORDINAT.SRIDID IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
+COMMENT ON COLUMN KOORDINAT.SX IS 'A posteriori spredning på førstekoordinaten.';
+COMMENT ON COLUMN KOORDINAT.SY IS 'A posteriori spredning på andenkoordinaten.';
+COMMENT ON COLUMN KOORDINAT.SZ IS 'A posteriori spredning på tredjekoordinaten.';
+COMMENT ON COLUMN KOORDINAT.T IS 'Observationstidspunktet.';
+COMMENT ON COLUMN KOORDINAT.FEJLMELDT IS 'Markering af at en koordinat er udgået fordi den er fejlbehæftet';
+COMMENT ON COLUMN KOORDINAT.TRANSFORMERET IS 'Angivelse om positionen er målt, eller transformeret fra et andet koordinatsystem';
+COMMENT ON COLUMN KOORDINAT.ARTSKODE IS 'Fra REFGEO. Værdierne skal forstås som følger:
+
+ artskode = 1 control point in fundamental network, first order.
+ artskode = 2 control point in superior plane network.
+ artskode = 2 control point in superior height network.
+ artskode = 3 control point in network of high quality.
+ artskode = 4 control point in network of lower or unknown quality.
+ artskode = 5 coordinate computed on just a few measurements.
+ artskode = 6 coordinate transformed from local or an not valid coordinate system.
+ artskode = 7 coordinate computed on an not valid coordinate system, or system of unknown origin.
+ artskode = 8 coordinate computed on few measurements, and on an not valid coordinate system.
+ artskode = 9 location coordinate or location height.
+
+ Artskode er kun tilgængelig for koordinater der stammer fra REFGEO.';
+COMMENT ON COLUMN KOORDINAT.X IS 'Førstekoordinat.';
+COMMENT ON COLUMN KOORDINAT.Y IS 'Andenkoordinat.';
+COMMENT ON COLUMN KOORDINAT.Z IS 'Tredjekoordinat.';
+COMMENT ON TABLE OBSERVATION IS 'Generisk observationsobjekt indeholdende informationer om en observation.';
+COMMENT ON COLUMN OBSERVATION.ANTAL IS 'Antal gentagne observationer hvoraf en middelobservationen er fremkommet.';
+COMMENT ON COLUMN OBSERVATION.GRUPPE IS 'ID der angiver observationsgruppen for en observation der indgår i en gruppe.';
+COMMENT ON COLUMN OBSERVATION.OBSERVATIONSTIDSPUNKT IS 'Tidspunktet hvor observationen er foretaget';
+COMMENT ON COLUMN OBSERVATION.OBSERVATIONSTYPEID IS 'Identifikation af en observations type.';
+COMMENT ON COLUMN OBSERVATION.OPSTILLINGSPUNKTID IS 'Udpegning af det punkt der er anvendt ved opstilling ved en observation.';
+COMMENT ON COLUMN OBSERVATION.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN OBSERVATION.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN OBSERVATION.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN OBSERVATION.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN OBSERVATION.SIGTEPUNKTID IS 'Udpegning af punkt der er sigtet til ved en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE1 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE10 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE11 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE12 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE13 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE14 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE15 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE2 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE3 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE4 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE5 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE6 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE7 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE8 IS 'En værdi for en observation.';
+COMMENT ON COLUMN OBSERVATION.VALUE9 IS 'En værdi for en observation.';
+COMMENT ON TABLE OBSERVATIONSTYPE IS 'Objekttype til beskrivelse af hvorledes en Observation skal læses, ud fra typen af observation.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.BESKRIVELSE IS 'Overordnet beskrivelse af denne observationstype.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.OBSERVATIONSTYPE IS 'Kortnavn for observationstypen, fx dH';
+COMMENT ON COLUMN OBSERVATIONSTYPE.OBSERVATIONSTYPEID IS 'Identifikation af observationenst type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.SIGTEPUNKT IS 'Indikator for om Sigtepunkt anvendes for denne observationstype.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE1 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE10 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE11 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE12 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE13 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE14 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE15 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE2 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE3 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE4 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE5 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE6 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE7 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE8 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON COLUMN OBSERVATIONSTYPE.VALUE9 IS 'Beskrivelse af en observations værdis betydning for afhænging af observationens type.';
+COMMENT ON TABLE PUNKT IS 'Abstrakt repræsentation af et fysisk punkt. Knytter alle punktinformationer sammen.';
+COMMENT ON COLUMN PUNKT.ID IS 'Persistent unik nøgle.';
+COMMENT ON COLUMN PUNKT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN PUNKT.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN PUNKT.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN PUNKT.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON TABLE PUNKTINFO IS 'Generisk information om et punkt.';
+COMMENT ON COLUMN PUNKTINFO.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
+COMMENT ON COLUMN PUNKTINFO.PUNKTID IS 'Punktet som punktinfo er holder information om.';
+COMMENT ON COLUMN PUNKTINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN PUNKTINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN PUNKTINFO.SAGSEVENTFRAID IS 'Angivelse af den hændelse der har bevirket registrering af et fikspunktsobjekt';
+COMMENT ON COLUMN PUNKTINFO.SAGSEVENTTILID IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
+COMMENT ON COLUMN PUNKTINFO.TAL IS 'Værdien for numeriske informationselementer';
+COMMENT ON COLUMN PUNKTINFO.TEKST IS 'Værdien for tekstinformationselementer';
+COMMENT ON TABLE PUNKTINFOTYPE IS 'Udfaldsrum for punktinforobjekter med definition af hvordan PunktInfo skal læses og beskrivelse af typen af punktinfo.';
+COMMENT ON COLUMN PUNKTINFOTYPE.ANVENDELSE IS 'Er det reelTal, tekst, eller ingen af disse, der angiver værdien';
+COMMENT ON COLUMN PUNKTINFOTYPE.BESKRIVELSE IS 'Beskrivelse af denne informationstypes art.';
+COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPE IS 'Arten af dette informationselement';
+COMMENT ON COLUMN PUNKTINFOTYPE.INFOTYPEID IS 'Unik ID for typen af Punktinfo.';
+COMMENT ON TABLE SAG IS 'Samling af administrativt relaterede sagshændelser.';
+COMMENT ON COLUMN SAG.ID IS 'Persistent unik nøgle.';
+COMMENT ON COLUMN SAG.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON TABLE SAGSEVENT IS 'Udvikling i sag som kan, men ikke behøver, medføre opdateringer af fikspunktregisterobjekter.';
+COMMENT ON COLUMN SAGSEVENT.EVENTTYPEID IS 'Identifikation af typen af en sagsevent.';
+COMMENT ON COLUMN SAGSEVENT.ID IS 'Persistent unik nøgle.';
+COMMENT ON COLUMN SAGSEVENT.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN SAGSEVENT.SAGSID IS 'Udpegning af den sag i fikspunktsforvalningssystemet som en event er foretaget i.';
+COMMENT ON TABLE SAGSEVENTINFO IS 'Informationer der knytter sig til en et sagsevent.';
+COMMENT ON COLUMN SAGSEVENTINFO.BESKRIVELSE IS 'Specifik beskrivelse af den aktuelle fremdrift.';
+COMMENT ON COLUMN SAGSEVENTINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN SAGSEVENTINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN SAGSEVENTINFO.SAGSEVENTID IS 'Den sagsevent som sagseventinfo har information om.';
+COMMENT ON COLUMN SAGSEVENTINFO_HTML.HTML IS 'Generisk operatørlæsbart orienterende rapportmateriale.';
+COMMENT ON TABLE SAGSEVENTINFO_MATERIALE IS 'Eksternt placeret materiale knyttet til en event';
+COMMENT ON COLUMN SAGSEVENTINFO_MATERIALE.MD5SUM IS 'Sum brugt til at kontrollere materialets integritet.';
+COMMENT ON COLUMN SAGSEVENTINFO_MATERIALE.STI IS 'Placering af materialet.';
+COMMENT ON TABLE SAGSINFO IS 'Samling af administrativt relaterede sagshændelser.';
+COMMENT ON COLUMN SAGSINFO.AKTIV IS 'Markerer om sagen er åben eller lukket.';
+COMMENT ON COLUMN SAGSINFO.BEHANDLER IS 'Angivelse af en sagsbehandler.';
+COMMENT ON COLUMN SAGSINFO.BESKRIVELSE IS 'Kort beskrivelse af en fikspunktssag.';
+COMMENT ON COLUMN SAGSINFO.JOURNALNUMMER IS 'Sagsmappeidentifikation i opmålings- og beregningssagsregistret.';
+COMMENT ON COLUMN SAGSINFO.REGISTRERINGFRA IS 'Tidspunktet hvor registreringen er foretaget.';
+COMMENT ON COLUMN SAGSINFO.REGISTRERINGTIL IS 'Tidspunktet hvor en ny registrering er foretaget på objektet, og hvor denne version således ikke længere er den seneste.';
+COMMENT ON COLUMN SAGSINFO.SAGSID IS 'Den sag som sagsinfo holder information for.';
+COMMENT ON TABLE SRIDTYPE IS 'Udfaldsrum for SRID-koordinatbeskrivelser.';
+COMMENT ON COLUMN SRIDTYPE.BESKRIVELSE IS 'Generel beskrivelse af systemet.';
+COMMENT ON COLUMN SRIDTYPE.SRID IS 'Den egentlige referencesystemindikator.';
+COMMENT ON COLUMN SRIDTYPE.SRIDID IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
+COMMENT ON COLUMN SRIDTYPE.X IS 'Beskrivelse af x-koordinatens indhold';
+COMMENT ON COLUMN SRIDTYPE.Y IS 'Beskrivelse af y-koordinatens indhold.';
+COMMENT ON COLUMN SRIDTYPE.Z IS 'Beskrivelse af z-koordinatens indhold.';
+
+
+-----------------------------------------------------------------------------------------
+--                                      TRIGGERS
+-----------------------------------------------------------------------------------------
 
 -- Triggere der sikrer at kun registreringtil kan opdateres i en tabel
 CREATE OR REPLACE TRIGGER AUD#BEREGNING
@@ -1130,14 +1152,14 @@ END IF;
 END;
 /
 
--------------------------------------------------------------------------------
--- Indhold til observationtype
--------------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------------------
+--                            PRÆDEFINERET TABELINDHOLD
+-----------------------------------------------------------------------------------------
 
 --
 -- Geometrisk nivellement
 --
-
 INSERT INTO observationstype (
     -- Overordnet beskrivelse
     beskrivelse,
@@ -1184,7 +1206,6 @@ VALUES (
 --
 -- Trigonometrisk nivellement
 --
-
 INSERT INTO observationstype (
     -- Overordnet beskrivelse
     beskrivelse,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -178,15 +178,6 @@ def srid(firedb):
 
 @pytest.fixture()
 def punktinformationtype(firedb):
-    try:
-        pi = firedb.hent_punktinformationtyper()[0]
-    except IndexError:
-        firedb.indset_punktinformationtype(
-            PunktInformationType(
-                name="ATTR:fixture",
-                anvendelse=PunktInformationTypeAnvendelse.FLAG,
-                beskrivelse="Punktinfotype oprettet af test fixture",
-            )
-        )
-        pi = firedb.hent_punktinformationtyper()[0]
+    pi = firedb.hent_punktinformationtype("ATTR:test")
+
     return pi

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -119,7 +119,7 @@ def observation(firedb, sagsevent, observationstype, punkt):
     sagsevent.eventtype = EventType.OBSERVATION_INDSAT
     o0 = Observation(
         sagsevent=sagsevent,
-        observationstidspunkt=func.sysdate(),
+        observationstidspunkt=func.current_timestamp(),
         observationstype=observationstype,
         opstillingspunkt=punkt,
         antal=1,
@@ -133,13 +133,13 @@ def observationer(firedb, sagsevent, observationstype, punkt):
     sagsevent.eventtype = EventType.OBSERVATION_INDSAT
     o0 = Observation(
         sagsevent=sagsevent,
-        observationstidspunkt=func.sysdate(),
+        observationstidspunkt=func.current_timestamp(),
         observationstype=observationstype,
         opstillingspunkt=punkt,
     )
     o1 = Observation(
         sagsevent=sagsevent,
-        observationstidspunkt=func.sysdate(),
+        observationstidspunkt=func.current_timestamp(),
         observationstype=observationstype,
         opstillingspunkt=punkt,
     )

--- a/test/gama/test_gama_cli_read.py
+++ b/test/gama/test_gama_cli_read.py
@@ -1,11 +1,9 @@
 import traceback
-import time
 
 import click
 from click.testing import CliRunner
 from pytest import approx
 
-import fire
 from fire.cli.gama import gama
 from fire.api import FireDb
 from fire.api.model import Sag
@@ -56,13 +54,3 @@ def test_cli(firedb: FireDb, sag: Sag):
 
         if koordinat.punkt.ident == "RDO1":
             assert koordinat.z == approx(86.1778)
-
-    # Hold en pause for at undgå opdatering af samme koordinater
-    # på samme tidspunkt i en senere test. Dette er nødvendigt da
-    # Oracles DATETIME type kun kan opløse et tidspunkt til nærmeste
-    # sekund. Da UNIQUE CONSTRAINT på koordinattabellen forbyder
-    # indsættelse af en ny koordinat på samme tidspunkt som den
-    # foregående holder vi altså en lille pause for at omgås den
-    # begrænsning i test-suiten. I praksis vil det aldrig være et
-    # problem.
-    time.sleep(1)

--- a/test/test_beregning.py
+++ b/test/test_beregning.py
@@ -26,7 +26,7 @@ def test_indset_beregning(
 ):
     o0 = Observation(
         sagsevent=sagsevent,
-        observationstidspunkt=func.sysdate(),
+        observationstidspunkt=func.current_timestamp(),
         observationstype=observationstype,
         opstillingspunkt=punkt,
     )

--- a/test/test_ddl.py
+++ b/test/test_ddl.py
@@ -120,6 +120,9 @@ def test_afregistrering_punktinfo(
     firedb.session.add(se)
     firedb.session.commit()
 
+    firedb.session.refresh(p1)
+    firedb.session.refresh(p2)
+
     assert p1.registreringtil == p2.registreringfra
     assert p1.sagseventtilid == p2.sagseventfraid
     assert p2.registreringtil is None
@@ -162,3 +165,18 @@ def test_afregistrering_sagseventinfo(firedb: FireDb, sagsevent: Sagsevent):
 
     assert si1.registreringtil == si2.registreringfra
     assert si2.registreringtil is None
+
+
+def test_timestamps(firedb: FireDb, koordinat: Koordinat):
+    """
+    Test at TIMESTAMPs kan opløse mikrosekunder.
+    """
+
+    timestamp = dt.datetime(2020, 9, 22, 13, 37, 12, 345)
+    koordinat.t = timestamp
+    firedb.session.add(koordinat)
+    firedb.session.commit()
+
+    firedb.session.refresh(koordinat)
+
+    assert koordinat.t == dt.datetime(2020, 9, 22, 13, 37, 12, 345)

--- a/test/test_ddl.py
+++ b/test/test_ddl.py
@@ -21,7 +21,7 @@ from fire.api.model import (
 
 def test_afregistrering_koordinat(firedb: FireDb, sag: Sag, punkt: Punkt, srid: Srid):
     """
-    Test trigger BID#KOORDINAT - Automatisk afrestrering af tidligere koordinat.
+    Test trigger koordinat_au_trg - Automatisk afrestrering af tidligere koordinat.
     """
     k1 = Koordinat(
         punkt=punkt,
@@ -62,7 +62,7 @@ def test_afregistrering_koordinat(firedb: FireDb, sag: Sag, punkt: Punkt, srid: 
 
 def test_indlæsning_af_lukket_koordinat(firedb: FireDb, koordinat: Koordinat):
     """
-    Test trigger BID#KOORDINAT.
+    Test trigger koordinat_bi_trg.
 
     Direkte indlæsning af en lukket koordinat er ikke tilladt, tjek at databasen
     brokker sig over det.
@@ -79,7 +79,7 @@ def test_indlæsning_af_lukket_koordinat(firedb: FireDb, koordinat: Koordinat):
 
 def test_indlæsning_af_lukket_punkt(firedb: FireDb, punkt: Punkt):
     """
-    Test trigger BID#PUNKT.
+    Test trigger punkt_bi_trg.
 
     Direkte indlæsning af et lukket punkt er ikke tilladt, tjek at databasen
     brokker sig over det.
@@ -98,7 +98,7 @@ def test_afregistrering_punktinfo(
     firedb: FireDb, sag: Sag, punkt: Punkt, punktinformationtype: PunktInformationType
 ):
     """
-    Test trigger PUNKTINFO_TYPE_VALID_TRG - Automatisk afrestrering af tidligere punktinfo.
+    Test trigger punktinfo_biu_trg - Automatisk afrestrering af tidligere punktinfo.
     """
     p1 = PunktInformation(
         punkt=punkt,
@@ -128,7 +128,7 @@ def test_afregistrering_punktinfo(
 
 def test_afregistrering_sagsinfo(firedb: FireDb, sag: Sag):
     """
-    Test trigger BID#SAGSINFO - Automatisk afrestrering af tidligere sagsinfo.
+    Test trigger sagsinfo_bi_trg - Automatisk afrestrering af tidligere sagsinfo.
     """
     si1 = Sagsinfo(
         sag=sag, behandler="B00001", beskrivelse="Første udgave", aktiv=Boolean.TRUE
@@ -149,7 +149,7 @@ def test_afregistrering_sagsinfo(firedb: FireDb, sag: Sag):
 
 def test_afregistrering_sagseventinfo(firedb: FireDb, sagsevent: Sagsevent):
     """
-    Test trigger BID#SAGSEVENTINFO - Automatisk afrestrering af tidligere sagseventinfo.
+    Test trigger sagseventinfo_bi_trg - Automatisk afrestrering af tidligere sagseventinfo.
     """
     si1 = SagseventInfo(sagsevent=sagsevent, beskrivelse="Første udgave")
 


### PR DESCRIPTION
Lidt af hvert:

1. Opdeling af DDL i sektioner
2. Omformateret så udtrykket er nogenlunde ens over det hele
3. Navngivning strømlinet for index, constraints og triggers
4. Fejlmeddelser oversat til dansk og flere fejlkoder benyttes
5. ISO-format for tidsstempler i DDL.

Closes #248 