### PR TITLE
Håndter andre brugerkonti end administratorkontoen

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -58,6 +58,7 @@ class FireDb(object):
             f"{self.dialect}://{self.connectionstring}",
             connect_args={"encoding": "UTF-8", "nencoding": "UTF-8"},
             echo=debug,
+            execution_options={"schema_translate_map": {None: "fire_adm"}},
         )
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.session = self.sessionmaker(autoflush=False)

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -55,7 +55,7 @@ class FireDb(object):
             self.connectionstring = self._build_connection_string()
 
         # Kører vi under test setup?
-        if self.connectionstring.startswith("fire.fire@localhost"):
+        if self.connectionstring.startswith("fire:fire@localhost"):
             exe_opt = {}
         else:
             exe_opt = {"schema_translate_map": {None: "fire_adm"}}

--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -54,11 +54,17 @@ class FireDb(object):
         else:
             self.connectionstring = self._build_connection_string()
 
+        # Kører vi under test setup?
+        if self.connectionstring.startswith("fire.fire@localhost"):
+            exe_opt = {}
+        else:
+            exe_opt = {"schema_translate_map": {None: "fire_adm"}}
+
         self.engine = create_engine(
             f"{self.dialect}://{self.connectionstring}",
             connect_args={"encoding": "UTF-8", "nencoding": "UTF-8"},
             echo=debug,
-            execution_options={"schema_translate_map": {None: "fire_adm"}},
+            execution_options=exe_opt,
         )
         self.sessionmaker = sessionmaker(bind=self.engine)
         self.session = self.sessionmaker(autoflush=False)


### PR DESCRIPTION
Read-onlykontoen, som bør være den primært anvendte, logger ind i et andet skema end administatorkontoen, og kan derfor ikke se tabellerne. Ved at indføre

                execution_options={"schema_translate_map": {None: "fire_adm"}},

i create_engine-kaldet i firedb.py præfikses alle tabelnavne uden skema med skemaet "fire_adm"