### PR TITLE
Forbedr Fikspunktregisterobjekt.__repr__

### DIFF
--- a/fire/api/model/__init__.py
+++ b/fire/api/model/__init__.py
@@ -49,10 +49,22 @@ class ReprBase(object):
 
     def __repr__(self):
         class_ = self.__class__.__name__
-        attrs = sorted(
-            (col.name, getattr(self, col.name)) for col in self.__table__.columns
-        )
-        sattrs = ", ".join("{}={!r}".format(*x) for x in attrs)
+
+        attrs = []
+        for col in self.__table__.columns:
+            try:
+                attrs.append((col.name, getattr(self, col.name)))
+            except AttributeError:
+                # Der er ikke altid et en til en match mellem kolonnenavn og attributnavn
+                try:
+                    # Mest almindeligt er at et "id" udelades i attributnavnet ...
+                    attributnavn = col.name.replace("id", "")
+                    attrs.append((attributnavn, getattr(self, attributnavn)))
+                except AttributeError:
+                    # ... og hvis mapningen er anderledes springes den over
+                    continue
+
+        sattrs = ", ".join("{}={!r}".format(*x) for x in sorted(attrs))
         return f"{class_}({sattrs})"
 
 


### PR DESCRIPTION
I tilfælde hvor en attribut på et tabelobjekt ikke matcher kolonnenavnet
ville en exception bliver rejst tidligere. Nu forsøges problemet løst
(fx hvor attributten er 'eventtype' men kolonnen hedder 'eventtypeid')
og lykkes det ikke springes attributten over.

Problemet observeret specifikt ved kald af `repr()`på et `Sagsevent` objekt.