### PR TITLE
Udtrækskosmetik

### DIFF
--- a/fire/cli/niv/ilæg_revision.py
+++ b/fire/cli/niv/ilæg_revision.py
@@ -388,7 +388,7 @@ def ilæg_revision(
 
     if test:
         fire.cli.print(
-            f" TESTEDE punktrevision for {projektnavn}:", bg="red", fg="white"
+            f"TESTEDE punktrevision for '{projektnavn}':", fg="yellow", bold=True
         )
         if koordinatoprettelsestekst != "":
             fire.cli.print(f"    * {koordinatoprettelsestekst}")

--- a/fire/cli/niv/udtræk_revision.py
+++ b/fire/cli/niv/udtræk_revision.py
@@ -117,6 +117,10 @@ def udtræk_revision(
                 if attributnavn == "IDENT:landsnr" and info.tekst == ident:
                     continue
 
+                # Vis kun identnavn i første række af hvert punkt
+                if i != indices[0]:
+                    ident = None
+
                 tekst = info.tekst
                 if tekst:
                     tekst = tekst.strip()
@@ -156,9 +160,9 @@ def udtræk_revision(
                 ignore_index=True,
             )
 
-            # To blanklinjer efter hvert punktoversigt
-            revision = revision.append({}, ignore_index=True)
-            revision = revision.append({}, ignore_index=True)
+            # Fem blanklinjer efter hvert punktoversigt
+            for i in range(5):
+                revision = revision.append({}, ignore_index=True)
 
     resultater = {"Revision": revision}
     skriv_ark(projektnavn, resultater, "-revision")

--- a/fire/cli/niv/udtræk_revision.py
+++ b/fire/cli/niv/udtræk_revision.py
@@ -161,8 +161,7 @@ def udtræk_revision(
             )
 
             # Fem blanklinjer efter hvert punktoversigt
-            for i in range(5):
-                revision = revision.append({}, ignore_index=True)
+            revision = revision.append(5 * [{}], ignore_index=True)
 
     resultater = {"Revision": revision}
     skriv_ark(projektnavn, resultater, "-revision")


### PR DESCRIPTION
Lidt bedre overblik ifbm punktrevision - både i skærmdialogen og i det udtrukne regneark:

1. Udelad unødvendige punktnavne i udtrækket
2. Læg flere blanklinjer mellem hvert punkt i udtrækket
3. Mere overskuelig skærmdialog under ilægning