### PR TITLE
Nogle mindre rettelser som har hobet sig op

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -111,7 +111,8 @@ def koordinat_linje(koord: Koordinat) -> str:
 
     if dimensioner == 3:
         linje = meta + f"{koord.x:.10f}, {koord.y:.10f}, {koord.z:.5f}"
-        linje += f"  ({koord.sx:.0f}, {koord.sy:.0f}, {koord.sz:.0f})"
+        if koord.sx is not None and koord.sy is not None and koord.sz is not None:
+            linje += f"  ({koord.sx:.0f}, {koord.sy:.0f}, {koord.sz:.0f})"
 
     return linje
 
@@ -525,7 +526,9 @@ def infotype(infotype: str, søg: bool, **kwargs):
     bredde = max([len(p.name) for p in punktinfotyper]) + 2
     for punktinfotype in punktinfotyper:
         besk = punktinfotype.beskrivelse.replace("-\n", "").replace("\n", " ").strip()
-        fire.cli.print(f"{punktinfotype.name:{bredde}} {besk}")
+        fire.cli.print(
+            f"{punktinfotype.infotypeid:{-4}} {punktinfotype.name:{bredde}} {besk}"
+        )
 
 
 @info.command()

--- a/fire/cli/niv/ilæg_revision.py
+++ b/fire/cli/niv/ilæg_revision.py
@@ -143,7 +143,7 @@ def ilæg_revision(
         if sridnavn not in sridnavne:
             continue
         try:
-            koord = [float(k) for k in r["Ny værdi"].split()]
+            koord = [float(k.replace(",", ".")) for k in r["Ny værdi"].split()]
         except ValueError as ex:
             fire.cli.print(
                 f"Slemt koordinatudtryk:\n{'    '.join(r['Ny værdi'])}\n{ex}"

--- a/fire/cli/niv/udtræk_revision.py
+++ b/fire/cli/niv/udtræk_revision.py
@@ -103,6 +103,11 @@ def udtræk_revision(
 
             anvendte_attributter = []
 
+            # Nedenfor sætter vi ident=None efter første linje, for at få en mere
+            # overskuelig rapportering. Men vi skal stadig have adgang til identen
+            # for at kunne fejlmelde undervejs
+            ident_til_fejlmelding = ident
+
             # Så itererer vi, med aktuelle beskrivelse først
             for i in indices:
                 info = punkt.punktinformationer[i]
@@ -149,7 +154,15 @@ def udtræk_revision(
                     },
                     ignore_index=True,
                 )
-            lokation = punkt.geometri.koordinater
+            try:
+                lokation = punkt.geometri.koordinater
+            except AttributeError:
+                fire.cli.print(
+                    f"NB! {ident_til_fejlmelding} mangler lokationskoordinat - bruger (11,56)",
+                    fg="yellow",
+                    bold=True,
+                )
+                lokation = (11.0, 56.0)
             revision = revision.append(
                 {
                     "Punkt": ident,


### PR DESCRIPTION
fire info punkt: udskriv kun koordinatspredninger hvis de ikke er None

fire info infotype: medtag infotypeid i søgelister

fire niv ilæg-revision: håndter både punktum og komma som decimalseparator

fire niv udtræk-revision: håndter punkter uden geometri