### PR TITLE
Overskriv foregående værdier af 'Ny kote', 'Ny σ'

### DIFF
--- a/fire/cli/niv/regn.py
+++ b/fire/cli/niv/regn.py
@@ -249,7 +249,6 @@ def gama_beregning(
     # Men rækkefølgen anvendt her passer sammen med det Gama præsenterer i
     # html-rapportudgaven af beregningsresultatet.
     koteliste = doc["gama-local-adjustment"]["coordinates"]["adjusted"]["point"]
-    print(f"koteliste: {koteliste}")
     punkter = [punkt["id"] for punkt in koteliste]
     koter = [float(punkt["z"]) for punkt in koteliste]
     varliste = doc["gama-local-adjustment"]["coordinates"]["cov-mat"]["flt"]

--- a/fire/cli/niv/regn.py
+++ b/fire/cli/niv/regn.py
@@ -249,6 +249,7 @@ def gama_beregning(
     # Men rækkefølgen anvendt her passer sammen med det Gama præsenterer i
     # html-rapportudgaven af beregningsresultatet.
     koteliste = doc["gama-local-adjustment"]["coordinates"]["adjusted"]["point"]
+    print(f"koteliste: {koteliste}")
     punkter = [punkt["id"] for punkt in koteliste]
     koter = [float(punkt["z"]) for punkt in koteliste]
     varliste = doc["gama-local-adjustment"]["coordinates"]["cov-mat"]["flt"]
@@ -259,6 +260,8 @@ def gama_beregning(
     punktoversigt["uuid"] = ""
     punktoversigt["Udelad publikation"] = ""
     punktoversigt["Fasthold"] = "x"
+    punktoversigt["Ny kote"] = None
+    punktoversigt["Ny σ"] = None
     punktoversigt["Δ-kote [mm]"] = None
     punktoversigt["Opløft [mm/år]"] = float("NaN")
     punktoversigt["System"] = "DVR90"


### PR DESCRIPTION
Undgå at tidligere udjævningsresultater for punkter,
der fastholdes i ny beregning, bløder igennem til
resultatregnearket.

Resolves #285