### PR TITLE
Fjern deprecated option fra gama-localinputfil

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - xlsxwriter
   - xlrd=1.2.0
   - xmltodict
-  - gama=2.09
+  - gama=2.13
   - pytest
   - pytest-cov
   - pytest-mock

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - xlsxwriter
   - xlrd=1.2.0
   - xmltodict
-  - gama=2.09
+  - gama=2.13

--- a/fire/cli/niv/regn.py
+++ b/fire/cli/niv/regn.py
@@ -178,7 +178,6 @@ def gama_beregning(
             f"    algorithm='gso' angles='400' conf-pr='0.95'\n"
             f"    cov-band='0' ellipsoid='grs80' latitude='55.7' sigma-act='apriori'\n"
             f"    sigma-apr='1.0' tol-abs='1000.0'\n"
-            f"    update-constrained-coordinates='no'\n"
             f"/>\n\n"
             f"<description>\n"
             f"    Nivellementsprojekt {ascii(projektnavn)}\n"  # Gama kaster op over Windows-1252 tegn > 127


### PR DESCRIPTION
update-constrained-coordinates='no' var frarådet
i GNU Gama version 2.09 og blev ikke accepteret
længere fra og med version 2.10

Vi fjerner det uacceptable input og skubber den
anvendte version frem til 2.13

Resolves #280