### PR TITLE
Opdater til pandas-1.2.1 og openpyxl-3.0.6

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,9 +10,9 @@ dependencies:
   - qgis=3.14
   - click
   - colorama
-  - pandas=1.1.2
+  - pandas=1.2.1
+  - openpyxl=3.0.6
   - xlsxwriter
-  - xlrd=1.2.0
   - xmltodict
   - gama=2.13
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - click
   - colorama
   - pyproj
-  - pandas=1.1.2
+  - pandas=1.2.1
+  - openpyxl=3.0.6
   - xlsxwriter
-  - xlrd=1.2.0
   - xmltodict
   - gama=2.13


### PR DESCRIPTION
Den tidligere anvendte pandas-1.1.2, fungerede
sammen med xlrd-1.2.0. xlrd er imidlertid under
udfasning, fordi dens xml-læser tilsyneladende
udgør en sikkerhedsbrist. Nyere udgaver (post
2.0.0) kan derfor ikke længere læse xlsxfiler,
men kun de aldrende binære xls-filer.

Vi opgraderer derfor fra xlrd til openpyxl og
ved samme lejlighed til en nyere og meget
hurtigere udgave af pandas.

Resolves #281