### PR TITLE
Reparer skriv_ark() efter opdatering af pandas

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,6 @@ dependencies:
   - colorama
   - pandas=1.2.1
   - openpyxl=3.0.6
-  - xlsxwriter
   - xmltodict
   - gama=2.13
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,5 @@ dependencies:
   - pyproj
   - pandas=1.2.1
   - openpyxl=3.0.6
-  - xlsxwriter
   - xmltodict
   - gama=2.13

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -222,7 +222,9 @@ def skriv_ark(
         try:
             with pd.ExcelWriter(filnavn) as writer:
                 for r in resultater:
-                    resultater[r].to_excel(writer, sheet_name=r, encoding="utf-8", index=False)
+                    resultater[r].to_excel(
+                        writer, sheet_name=r, encoding="utf-8", index=False
+                    )
             if suffix == "-resultat":
                 os.startfile(f"{projektnavn}-resultat.xlsx")
             return

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -217,23 +217,22 @@ def skriv_ark(
         fire.cli.print(f"Skriver: {tuple(resultater)}")
         fire.cli.print(f"Til filen '{filnavn}'")
 
-    writer = pd.ExcelWriter(filnavn, engine="xlsxwriter")
-    for r in resultater:
-        resultater[r].to_excel(writer, sheet_name=r, encoding="utf-8", index=False)
-
     # Giv brugeren en chance for at lukke et åbent regneark
     while True:
         try:
-            writer.save()
+            with pd.ExcelWriter(filnavn) as writer:
+                for r in resultater:
+                    resultater[r].to_excel(writer, sheet_name=r, encoding="utf-8", index=False)
             if suffix == "-resultat":
                 os.startfile(f"{projektnavn}-resultat.xlsx")
             return
-        except:
+        except Exception as ex:
             fire.cli.print(
                 f"Kan ikke skrive til '{filnavn}' - måske fordi den er åben.",
                 fg="yellow",
                 bold=True,
             )
+            fire.cli.print(f"Anden mulig årsag: {ex}")
             if input("Prøv igen ([j]/n)? ") in ["j", "J", "ja", ""]:
                 continue
             fire.cli.print("Dropper skrivning")


### PR DESCRIPTION
Efter opdatering af pandas til 1.2.1 sker kontrollen for
om en excelfil er åben allerede når writerelementet
instantieres, ikke først når man forsøger at skrive til
filen.

Det er i modstid med logikken bag "spørg brugeren om man
har glemt at lukke arket før skrivning" i skriv_ark(), som
derfor opdateres.

Da vi for nylig har introduceret afhængighed af openpyxl
behøver vi ikke længere at bruge xlsxwriter til skrivning
af excelfiler: Den reparerede logik benytter nu openpyxl
og xlsxwriter er fjernet fra miljødefinitionsfilerne.

Endvidere er fejlbeskrivelsen i brugerdialogen forbedret,
så den er konsistent mellem find_faneblad() og skriv_ark().