### PR TITLE
Justering af observationers/koters persistering

### DIFF
--- a/fire/cli/niv/ilæg_nye_koter.py
+++ b/fire/cli/niv/ilæg_nye_koter.py
@@ -132,8 +132,15 @@ def ilæg_nye_koter(
     sagsevent.sagseventinfos.append(sagseventinfo)
 
     # Generer dokumentation til fanebladet "Sagsgang"
+    # Variablen "registreringstidspunkt" har værdien "CURRENT_TIMESTAMP"
+    # som udvirker mikrosekundmagi når den bliver skrevet til databasen,
+    # men ikke er meget informativ for en menneskelig læser her i regne-
+    # arkenes prosaiske verden. Derfor benytter vi pd.Timestamp.now(),
+    # som ikke har mikrosekundmagi over sig, men som kan læses og giver
+    # mening, selv om den ikke bliver eksakt sammenfaldende med det
+    # tidsstempel hændelsen får i databasen. Det lever vi med.
     sagsgangslinje = {
-        "Dato": registreringstidspunkt,
+        "Dato": pd.Timestamp.now(),
         "Hvem": sagsbehandler,
         "Hændelse": "Koteberegning",
         "Tekst": sagseventtekst,

--- a/fire/cli/niv/ilæg_observationer.py
+++ b/fire/cli/niv/ilæg_observationer.py
@@ -150,9 +150,10 @@ def ilæg_observationer(
                 value1=obs.ΔH,
                 value2=obs.L,
                 value3=obs.Opst,
-                # value4=Refraktion, eta_1, sættes her til None
+                value4=0.0,  # Refraktion, eta_1, er defineret som non-null, så vi sætter den til 0 istf. None
                 value5=obs.σ,
                 value6=obs.δ,
+                value7=0,  # 1,2,3 henviser til 1.,2.,3. præcisionsnivellement. 0 til "ingen af dem"
             )
         else:
             fire.cli.print(


### PR DESCRIPTION
MGL-observationer blev fejlagtigt instantieret med value4=None og
value7=None.

value4 er den, for gamle MGL-målingers vedkommende, registrerede
refraktionsrelaterede koefficient. Den benyttes ikke længere, men
er i DDL defineret som non-null - så vi sætter den nu til 0 istf
None.

value7 angiver, med værdien 1,2,3 om observationen hører til et af
de tre præcisionsnivellementer. value7 er også defineret som non-
null. Vi må derfor sætte den til 0, i overensstemmelse med DDLen.

Sagshændelser vedrørende koteopdateringer blev i regnearket tids-
stemplet med tekststrengen "CURRENT_TIMESTAMP", som ved skrivning
til databasen udfoldes til nanosekundopløsningstidsstempel. Excel
er mindre samarbejdsvillig desangående, så vi må i stedet trække
en værdi fra Pandas' Timestamp.now()-funktion.

Med disse få rettelser fungerer multipel persistering for koter
og observationer. Det tilsvarende for nyoprettede punkter er mere
kompliceret, og uden for dette commits ambitionsvidde.