### PR TITLE
Fastlås pakkeversioner i condamiljøer

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,28 +3,27 @@ channels:
   - conda-forge
   - msys2
 dependencies:
-  - python=3.7
-  - cx_oracle=7.0
-  - sqlalchemy=1.2.13
-  - pyproj
-  - qgis=3.14
-  - click
-  - colorama
-  - pandas=1.2.1
-  - openpyxl=3.0.6
-  - xmltodict
-  - gama=2.13
-  - pytest
-  - pytest-cov
-  - pytest-mock
-  - sphinx
-  - sphinx_rtd_theme
-  - sphinx-click
-  - black
-  - pylint
-  - sqlalchemy_schemadisplay
-  - fiona
-  - m2-zip
-  - pip
+  - black=20.8b1.*
+  - click=7.1.*
+  - cx_oracle=7.0.*
+  - fiona=1.8.*
+  - gama=2.13.*
+  - m2-zip=3.0.*
+  - openpyxl=3.0.*
+  - pandas=1.2.*
+  - pip=21.0.*
+  - pylint=2.6.*
+  - pyproj=2.6.*
+  - pytest=6.2.*
+  - pytest-cov=2.11.*
+  - pytest-mock=3.5.*
+  - python=3.7.*
+  - qgis=3.16.*
+  - sphinx=3.4.*
+  - sphinx-click=2.5.*
+  - sphinx_rtd_theme=0.5.*
+  - sqlalchemy_schemadisplay=1.3.*
+  - sqlalchemy=1.2.*
+  - xmltodict=0.12.*
   - pip:
-     - pb_tool
+     - pb_tool==3.1.*

--- a/environment.yml
+++ b/environment.yml
@@ -2,14 +2,13 @@ name: fire
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - cx_oracle=7.0
-  - sqlalchemy=1.2.13
-  - qgis=3.10
-  - click
-  - colorama
-  - pyproj
-  - pandas=1.2.1
-  - openpyxl=3.0.6
-  - xmltodict
-  - gama=2.13
+  - click=7.1.*
+  - cx_oracle=7.0.*
+  - gama=2.13.*
+  - openpyxl=3.0.*
+  - pandas=1.2.*
+  - pyproj=2.6.*
+  - python=3.7.*
+  - qgis=3.16.*
+  - sqlalchemy=1.2.*
+  - xmltodict=0.12.*


### PR DESCRIPTION
Fastlås MAJOR- og MINOR-elementerne i alle semantiske versionstripler
for pakker anvendt i FIREs conda-pakkemiljøer "fire" og "fire-dev".

PATCH-elementerne får lov at flyde, så vi får sikkerhedsopdateringer
indført ved miljøopdateringer ("conda env update --file ...").

Fastlåsningen sker for at undgå at opdateringer på conda-forge fører
til inkompatibilitet med den primære FIRE-kildekode. Dette har i
praksis vist sig at være et problem.

Da der alligevel indføres ændringer i de fleste linjer i miljødefi-
nitionsfilerne "environment.yml" og "environment-dev.yml" er lejlig-
heden også benyttet til at reorganisere linjerne, så alle afhængig-
heder oplistes i alfabetisk orden. Det gør det blandt andet noget
lettere at sammenligne de to miljødefinitioner.

Resolves #290, #291