### PR TITLE
Tillad valg af database på kommandolinjen

### DIFF
--- a/.circleci/fire.ini
+++ b/.circleci/fire.ini
@@ -1,10 +1,11 @@
-[connection]
+[prod_connection]
 password = fire
 username = fire
 hostname = localhost
 database = xe
 service = fire
 method = database
+schema =
 
 [test_connection]
 password = fire
@@ -13,6 +14,17 @@ hostname = localhost
 database = xe
 service = fire
 method = database
+schema =
+
+[ci_connection]
+password = fire
+username = fire
+hostname = localhost
+database = xe
+service = fire
+method = database
+schema =
+
 
 # GNU GAMA KONFIGURATION
 #

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -143,7 +143,7 @@ måde
     password = <adgangskode>
     username = <brugernavn>
     hostname = <netværksadresse>
-    methode = <database|service>
+    method = <database|service>
     database = <databasenavn>
     service = <servicenavn>
     schema = <schema>
@@ -152,7 +152,7 @@ måde
     password = <adgangskode>
     username = <brugernavn>
     hostname = <netværksadresse>
-    methode = <database|service>
+    method = <database|service>
     database = <databasenavn>
     service = <servicenavn>
     schema = <schema>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -136,12 +136,28 @@ måde
 
 .. code-block:: ini
 
-    [connection]
+    [general]
+    default_connection = prod
+
+    [prod_connection]
     password = <adgangskode>
     username = <brugernavn>
     hostname = <netværksadresse>
+    methode = <database|service>
     database = <databasenavn>
     service = <servicenavn>
+    schema = <schema>
+
+    [test_connection]
+    password = <adgangskode>
+    username = <brugernavn>
+    hostname = <netværksadresse>
+    methode = <database|service>
+    database = <databasenavn>
+    service = <servicenavn>
+    schema = <schema>
+
+
 
 .. note::
 

--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -5,7 +5,6 @@ from fire.api import FireDb
 firedb = FireDb()
 _show_colors = True
 
-
 # Create decorator that handles all default options
 def _set_monochrome(ctx, param, value):
     """
@@ -23,7 +22,22 @@ def _set_debug(ctx, param, value):
     firedb.engine.echo = value
 
 
+def _set_database(ctx, param, value):
+    """
+    Vælg en specifik databaseforbindelse.
+    """
+    if value is not None:
+        new_firedb = FireDb(db=str(value).lower())
+        override_firedb(new_firedb)
+
+
 _default_options = [
+    click.option(
+        "--db",
+        type=click.Choice(["prod", "test"]),
+        default=None,
+        callback=_set_database,
+    ),
     click.option(
         "-m",
         "--monokrom",
@@ -52,6 +66,7 @@ def print(*args, **kwargs):
     Tilsidesætter farven når --monokrom parameteren anvendes i
     kommandolinjekald.
     """
+
     kwargs["color"] = _show_colors
     click.secho(*args, **kwargs)
 
@@ -59,8 +74,7 @@ def print(*args, **kwargs):
 def override_firedb(new_firedb):
     """
     Tillad at bruge en anden firedb end den der oprettes automatisk af
-    fire.cli. Primært brugbar i forbindelse med afvikling af test-suite,
-    hvor fire.cli ellers vil arbejde op mod produktionsdatabasen.
+    fire.cli.
     """
     global firedb
     firedb = new_firedb

--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -36,7 +36,7 @@ _default_options = [
 ]
 
 
-def default_options():
+def default_options(**kwargs):
     def _add_options(func):
         for option in reversed(_default_options):
             func = option(func)

--- a/fire/cli/gama.py
+++ b/fire/cli/gama.py
@@ -1,6 +1,6 @@
 import click
 
-from fire.cli import firedb
+import fire.cli
 from fire.cli.utils import Datetime
 from fire.api.model import Geometry
 from fire.api.gama import GamaReader, GamaWriter
@@ -85,7 +85,7 @@ def write(
     fixpunkterfil,
 ):
     """Skriv en gama input fil"""
-    writer = GamaWriter(firedb, output)
+    writer = GamaWriter(fire.cli.firedb, output)
 
     g = None
 
@@ -99,9 +99,11 @@ def write(
             g = Geometry(wkt)
 
         if fra is not None and til is not None:
-            observations = firedb.hent_observationer_naer_geometri(g, buffer, fra, til)
+            observations = fire.cli.firedb.hent_observationer_naer_geometri(
+                g, buffer, fra, til
+            )
         else:
-            observations = firedb.hent_observationer_naer_geometri(g, buffer)
+            observations = fire.cli.firedb.hent_observationer_naer_geometri(g, buffer)
         writer.take_observations(observations)
 
     if fixpunkter is not None or fixpunkterfil is not None:
@@ -113,7 +115,7 @@ def write(
         fixpunkter_list = [pkt.strip() for pkt in fixpunkter_literal.split(",")]
         writer.set_fixed_point_ids(fixpunkter_list)
 
-    writer.write(True, False, "Created by fire-gama", firedb.config)
+    writer.write(True, False, "Created by fire-gama", fire.cli.firedb.config)
 
 
 @gama.command()
@@ -129,7 +131,7 @@ def write(
 )
 def read(input, case_id):
     """Læs en gama resultatfil (se --help)"""
-    reader = GamaReader(firedb, input)
+    reader = GamaReader(fire.cli.firedb, input)
     reader.read(case_id)
 
 

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -11,7 +11,6 @@ from pyproj import CRS
 from pyproj.exceptions import CRSError
 
 import fire.cli
-from fire.cli import firedb
 from fire.cli.utils import klargør_ident_til_søgning
 from fire.api.model import (
     Punkt,
@@ -382,7 +381,7 @@ def punkt(
     ident = klargør_ident_til_søgning(ident)
 
     try:
-        punkter = firedb.hent_punkter(ident)
+        punkter = fire.cli.firedb.hent_punkter(ident)
     except NoResultFound:
         fire.cli.print(f"Fejl: Kunne ikke finde {ident}.", fg="red", err=True)
         sys.exit(1)
@@ -423,10 +422,10 @@ def srid(srid: str, ts: bool, **kwargs):
     """
     if not srid:
         if ts:
-            srid_db = firedb.session.query(Srid).order_by(Srid.name).all()
+            srid_db = fire.cli.firedb.session.query(Srid).order_by(Srid.name).all()
         else:
             srid_db = (
-                firedb.session.query(Srid)
+                fire.cli.firedb.session.query(Srid)
                 .filter(not_(Srid.name.like("TS:%")))
                 .order_by(Srid.name)
                 .all()
@@ -439,7 +438,7 @@ def srid(srid: str, ts: bool, **kwargs):
         srid_name = srid
 
         try:
-            srid = firedb.hent_srid(srid_name)
+            srid = fire.cli.firedb.hent_srid(srid_name)
         except NoResultFound:
             fire.cli.print(f"Error! {srid_name} not found!", fg="red", err=True)
             sys.exit(1)
@@ -476,7 +475,7 @@ def infotype(infotype: str, søg: bool, **kwargs):
     try:
         if søg:
             punktinfotyper = (
-                firedb.session.query(PunktInformationType)
+                fire.cli.firedb.session.query(PunktInformationType)
                 .filter(
                     or_(
                         PunktInformationType.name.ilike(f"%{infotype}%"),
@@ -488,7 +487,7 @@ def infotype(infotype: str, søg: bool, **kwargs):
             )
         else:
             punktinfotyper = (
-                firedb.session.query(PunktInformationType)
+                fire.cli.firedb.session.query(PunktInformationType)
                 .filter(PunktInformationType.name.ilike(f"{infotype}%"))
                 .order_by(PunktInformationType.name)
                 .all()
@@ -541,7 +540,7 @@ def obstype(obstype: str, **kwargs):
     Anføres `obstype` ikke gives liste af mulige obstyper.
     """
     if not obstype:
-        obstyper = firedb.hent_observationstyper()
+        obstyper = fire.cli.firedb.hent_observationstyper()
         for obstype in obstyper:
             beskrivelse = textwrap.shorten(
                 obstype.beskrivelse, width=70, placeholder="..."
@@ -550,7 +549,7 @@ def obstype(obstype: str, **kwargs):
 
         return 0
 
-    ot = firedb.hent_observationstype(obstype)
+    ot = fire.cli.firedb.hent_observationstype(obstype)
     if ot is None:
         fire.cli.print(f"Fejl! {obstype} ikke fundet!", fg="red", err=True)
         sys.exit(1)
@@ -575,9 +574,8 @@ def sag(sagsid: str, **kwargs):
 
     Kaldes `fire info sag` uden sagsid listes alle aktive sager
     """
-
     if sagsid:
-        sag = firedb.hent_sag(sagsid)
+        sag = fire.cli.firedb.hent_sag(sagsid)
 
         fire.cli.print(
             "------------------------- SAG -------------------------", bold=True
@@ -611,7 +609,7 @@ def sag(sagsid: str, **kwargs):
 
         return
 
-    sager = firedb.hent_alle_sager()
+    sager = fire.cli.firedb.hent_alle_sager()
     fire.cli.print("Sagsid     Behandler           Beskrivelse", bold=True)
     fire.cli.print("---------  ------------------  -----------")
     for sag in sager:

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -10,7 +10,6 @@ import pandas as pd
 from pyproj import Proj
 
 import fire.cli
-from fire.cli import firedb
 from fire.api.model import (
     Point,
     Punkt,
@@ -276,7 +275,7 @@ def find_sag(projektnavn: str) -> Sag:
     sagsgang = find_sagsgang(projektnavn)
     sagsid = find_sagsid(sagsgang)
     try:
-        sag = firedb.hent_sag(sagsid)
+        sag = fire.cli.firedb.hent_sag(sagsid)
     except:
         fire.cli.print(
             f" Sag for {projektnavn} er endnu ikke oprettet - brug fire niv opret-sag! ",

--- a/fire/cli/niv/ilæg_nye_koter.py
+++ b/fire/cli/niv/ilæg_nye_koter.py
@@ -5,7 +5,6 @@ import pandas as pd
 from sqlalchemy import func
 
 import fire.cli
-from fire.cli import firedb
 from fire import uuid
 from fire.api.model import (
     EventType,
@@ -80,7 +79,7 @@ def ilæg_nye_koter(
     punktoversigt = punktoversigt.replace("nan", "")
     ny_punktoversigt = punktoversigt[0:0]
 
-    DVR90 = firedb.hent_srid("EPSG:5799")
+    DVR90 = fire.cli.firedb.hent_srid("EPSG:5799")
     registreringstidspunkt = func.current_timestamp()
     tid = gyldighedstidspunkt(projektnavn)
 
@@ -99,7 +98,7 @@ def ilæg_nye_koter(
             ny_punktoversigt = ny_punktoversigt.append(punktdata, ignore_index=True)
             continue
 
-        punkt = firedb.hent_punkt(punktdata["Punkt"])
+        punkt = fire.cli.firedb.hent_punkt(punktdata["Punkt"])
         opdaterede_punkter.append(punkt)
         punktdata["uuid"] = sagsevent.id
 
@@ -156,7 +155,7 @@ def ilæg_nye_koter(
         return
 
     sagsevent.koordinater = til_registrering
-    firedb.indset_sagsevent(sagsevent)
+    fire.cli.firedb.indset_sagsevent(sagsevent)
 
     # Skriv resultater til resultatregneark
     ny_punktoversigt = ny_punktoversigt.replace("nan", "")

--- a/fire/cli/niv/ilæg_nye_punkter.py
+++ b/fire/cli/niv/ilæg_nye_punkter.py
@@ -5,7 +5,6 @@ import click
 import pandas as pd
 
 import fire.cli
-from fire.cli import firedb
 from fire import uuid
 from fire.api.model import (
     GeometriObjekt,
@@ -80,9 +79,11 @@ def ilæg_nye_punkter(
         fire.cli.print("Ingen nyetablerede punkter at registrere")
         return
 
-    landsnummer_pit = firedb.hent_punktinformationtype("IDENT:landsnr")
-    beskrivelse_pit = firedb.hent_punktinformationtype("ATTR:beskrivelse")
-    h_over_terræn_pit = firedb.hent_punktinformationtype("AFM:højde_over_terræn")
+    landsnummer_pit = fire.cli.firedb.hent_punktinformationtype("IDENT:landsnr")
+    beskrivelse_pit = fire.cli.firedb.hent_punktinformationtype("ATTR:beskrivelse")
+    h_over_terræn_pit = fire.cli.firedb.hent_punktinformationtype(
+        "AFM:højde_over_terræn"
+    )
     assert landsnummer_pit is not None, "Rådden landsnummer_pit"
     assert beskrivelse_pit is not None, "Rådden beskrivelse_pit"
     assert h_over_terræn_pit is not None, "Rådden h_over_terræn_pit"
@@ -203,10 +204,10 @@ def ilæg_nye_punkter(
             else:
                 afm_id = afm_ids.get(afm, 4999)
 
-            afmærkning_pit = firedb.hent_punktinformationtype(f"AFM:{afm_id}")
+            afmærkning_pit = fire.cli.firedb.hent_punktinformationtype(f"AFM:{afm_id}")
             if afmærkning_pit is None:
                 afm_id = 4999
-                afmærkning_pit = firedb.hent_punktinformationtype("AFM:4999")
+                afmærkning_pit = fire.cli.firedb.hent_punktinformationtype("AFM:4999")
             beskrivelse = (
                 afmærkning_pit.beskrivelse.replace("-\n", "")
                 .replace("\n", " ")
@@ -263,8 +264,7 @@ def ilæg_nye_punkter(
 
     if alvor:
         # Persister punkterne til databasen
-        # firedb.indset_flere_punkter(sagsevent, list(genererede_punkter.values()))
-        firedb.indset_sagsevent(sagsevent)
+        fire.cli.firedb.indset_sagsevent(sagsevent)
 
         # ... og marker i regnearket at det er sket
         for k in genererede_punkter.keys():
@@ -287,9 +287,9 @@ def ilæg_nye_punkter(
 
 
 def find_alle_løbenumre_i_distrikt(distrikt: str) -> List[str]:
-    pit = firedb.hent_punktinformationtype("IDENT:landsnr")
+    pit = fire.cli.firedb.hent_punktinformationtype("IDENT:landsnr")
     landsnumre = (
-        firedb.session.query(PunktInformation)
+        fire.cli.firedb.session.query(PunktInformation)
         .filter(
             PunktInformation.infotypeid == pit.infotypeid,
             PunktInformation.tekst.startswith(distrikt),

--- a/fire/cli/niv/ilæg_observationer.py
+++ b/fire/cli/niv/ilæg_observationer.py
@@ -5,7 +5,6 @@ import pandas as pd
 from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
-from fire.cli import firedb
 from fire import uuid
 from fire.api.model import (
     EventType,
@@ -67,8 +66,8 @@ def ilæg_observationer(
     if alvor and test:
         return
 
-    obstype_trig = firedb.hent_observationstype("trigonometrisk_koteforskel")
-    obstype_geom = firedb.hent_observationstype("geometrisk_koteforskel")
+    obstype_trig = fire.cli.firedb.hent_observationstype("trigonometrisk_koteforskel")
+    obstype_geom = fire.cli.firedb.hent_observationstype("geometrisk_koteforskel")
     til_registrering = []
 
     observationer = find_faneblad(projektnavn, "Observationer", ARKDEF_OBSERVATIONER)
@@ -106,9 +105,9 @@ def ilæg_observationer(
         # objekt af typen Observation
         try:
             punktnavn = obs.Fra
-            punkt_fra = firedb.hent_punkt(punktnavn)
+            punkt_fra = fire.cli.firedb.hent_punkt(punktnavn)
             punktnavn = obs.Til
-            punkt_til = firedb.hent_punkt(punktnavn)
+            punkt_til = fire.cli.firedb.hent_punkt(punktnavn)
         except NoResultFound:
             fire.cli.print(f"Ukendt punkt: '{punktnavn}'", fg="red", bg="white")
             sys.exit(1)
@@ -177,7 +176,7 @@ def ilæg_observationer(
     fire.cli.print(f"Skriver {len(til_registrering)} observationer")
     try:
         sagsevent.observationer = til_registrering
-        firedb.indset_sagsevent(sagsevent)
+        fire.cli.firedb.indset_sagsevent(sagsevent)
 
     except Exception as ex:
         fire.cli.print(

--- a/fire/cli/niv/læs_observationer.py
+++ b/fire/cli/niv/læs_observationer.py
@@ -9,7 +9,6 @@ import pandas as pd
 from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
-from fire.cli import firedb
 
 from . import (
     ARKDEF_FILOVERSIGT,
@@ -98,7 +97,7 @@ def importer_observationer(projektnavn: str) -> pd.DataFrame:
 
     for punktnavn in observerede_punkter:
         try:
-            punkt = firedb.hent_punkt(punktnavn)
+            punkt = fire.cli.firedb.hent_punkt(punktnavn)
             ident = punkt.ident
             fire.cli.print(f"Fandt {ident}", fg="green")
         except NoResultFound:
@@ -176,7 +175,7 @@ def opbyg_punktoversigt(
     nye_punkter = tuple(sorted(set(nyetablerede.index)))
 
     try:
-        DVR90 = firedb.hent_srid("EPSG:5799")
+        DVR90 = fire.cli.firedb.hent_srid("EPSG:5799")
     except KeyError:
         fire.cli.print(
             "DVR90 (EPSG:5799) ikke fundet i srid-tabel", bg="red", fg="white", err=True
@@ -190,7 +189,7 @@ def opbyg_punktoversigt(
             continue
 
         fire.cli.print(f"Finder kote for {punkt}", fg="green")
-        pkt = firedb.hent_punkt(punkt)
+        pkt = fire.cli.firedb.hent_punkt(punkt)
 
         # Grav aktuel kote frem
         kote = None

--- a/fire/cli/niv/netoversigt.py
+++ b/fire/cli/niv/netoversigt.py
@@ -5,7 +5,6 @@ import click
 import pandas as pd
 
 import fire.cli
-from fire.cli import firedb
 
 from . import (
     ARKDEF_NYETABLEREDE_PUNKTER,

--- a/fire/cli/niv/opret_sag.py
+++ b/fire/cli/niv/opret_sag.py
@@ -7,7 +7,6 @@ import sys
 
 from fire import uuid
 import fire.cli
-from fire.cli import firedb
 
 from . import (
     ARKDEF_FILOVERSIGT,
@@ -70,7 +69,7 @@ def opret_sag(projektnavn: str, sagsbehandler: str, beskrivelse: str, **kwargs) 
         sagsinfo = Sagsinfo(
             aktiv="true", behandler=sagsbehandler, beskrivelse=beskrivelse
         )
-        firedb.indset_sag(Sag(id=sag["uuid"], sagsinfos=[sagsinfo]))
+        fire.cli.firedb.indset_sag(Sag(id=sag["uuid"], sagsinfos=[sagsinfo]))
         fire.cli.print(f"Sag '{projektnavn}' oprettet")
     else:
         fire.cli.print("Opretter IKKE sag")

--- a/fire/cli/niv/regn.py
+++ b/fire/cli/niv/regn.py
@@ -9,7 +9,6 @@ import pandas as pd
 import xmltodict
 
 import fire.cli
-from fire.cli import firedb
 
 from fire.api.model import (
     Punkt,

--- a/fire/cli/niv/udtræk_revision.py
+++ b/fire/cli/niv/udtræk_revision.py
@@ -5,7 +5,6 @@ import pandas as pd
 from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
-from fire.cli import firedb
 
 from . import (
     ARKDEF_REVISION,
@@ -57,7 +56,7 @@ def udtræk_revision(
     for distrikt in opmålingsdistrikter:
         fire.cli.print(f"Behandler distrikt {distrikt}")
         try:
-            punkter = firedb.soeg_punkter(f"{distrikt}%")
+            punkter = fire.cli.firedb.soeg_punkter(f"{distrikt}%")
         except NoResultFound:
             punkter = []
         fire.cli.print(f"Der er {len(punkter)} punkter i distrikt {distrikt}")

--- a/fire/cli/søg/punkt.py
+++ b/fire/cli/søg/punkt.py
@@ -5,7 +5,6 @@ import click
 from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
-from fire.cli import firedb
 from fire.cli.utils import klargør_ident_til_søgning
 from . import søg
 
@@ -37,7 +36,7 @@ def punkt(ident: str, antal: int, **kwargs):
     ident_pattern = ident.replace("%", ".*")
 
     try:
-        punkter = firedb.soeg_punkter(ident, antal)
+        punkter = fire.cli.firedb.soeg_punkter(ident, antal)
     except NoResultFound:
         fire.cli.print(
             f"Fejl: Kunne ikke finde {ident.replace('%', '')}.", fg="red", err=True

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,25 +21,6 @@ from fire.api.model import (
 )
 
 
-class TestFireDb(FireDb):
-    """
-    FireDb that connects to DB with login data from
-    'test_connection' section of config file
-    """
-
-    _exe_opt = {}
-
-    def _build_connection_string(self):
-        # Establish connection to database
-        username = self.config.get("test_connection", "username")
-        password = self.config.get("test_connection", "password")
-        hostname = self.config.get("test_connection", "hostname")
-        database = self.config.get("test_connection", "database")
-        port = self.config.get("test_connection", "port", fallback=1521)
-
-        return f"{username}:{password}@{hostname}:{port}/{database}"
-
-
 class DummyFireDb(FireDb):
     """
     FireDb klasse der bruges i tests hvor databaseudtræk med
@@ -53,7 +34,7 @@ class DummyFireDb(FireDb):
         }
 
 
-persistent_firedb = TestFireDb(debug=False)
+persistent_firedb = FireDb(db="ci", debug=False)
 fire.cli.override_firedb(persistent_firedb)
 
 


### PR DESCRIPTION
Her indføres flere ting:

1. prod, test og ci databaseforbindelser i `fire.ini` 
2. mulighed for at sætte en standarddatabaseforbindelse
3. mulighed for at angive schema i `fire.ini` frem for at hardcode. Hvis ikke sat i `fire.ini` faldes tilbage på `fire_adm` skemaet.
4. `--db` option tilføjet kommandolinjeværktøjer. Uden `--db` bruges standarddatabaseforbindelsen (alternativt prod), ellers vælges database med `--db=test` eller `--db=prod`.

Se commit messages for yderligere information.