### PR TITLE
tilpas opret sag, så hjælpetekst er korrekt, og nyskrevet regneark åbnes for manuel kontrol

### DIFF
--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -209,7 +209,7 @@ def normaliser_placeringskoordinat(λ: float, φ: float) -> Tuple[float, float]:
 # -----------------------------------------------------------------------------
 def skriv_ark(
     projektnavn: str, resultater: Dict[str, pd.DataFrame], suffix: str = "-resultat"
-) -> None:
+) -> bool:
     """Skriv resultater til excel-fil"""
 
     filnavn = f"{projektnavn}{suffix}.xlsx"
@@ -227,7 +227,7 @@ def skriv_ark(
                     )
             if suffix == "-resultat":
                 os.startfile(f"{projektnavn}-resultat.xlsx")
-            return
+            return True
         except Exception as ex:
             fire.cli.print(
                 f"Kan ikke skrive til '{filnavn}' - måske fordi den er åben.",
@@ -238,7 +238,7 @@ def skriv_ark(
             if input("Prøv igen ([j]/n)? ") in ["j", "J", "ja", ""]:
                 continue
             fire.cli.print("Dropper skrivning")
-            return
+            return False
 
 
 # ------------------------------------------------------------------------------

--- a/fire/cli/niv/opret_sag.py
+++ b/fire/cli/niv/opret_sag.py
@@ -41,7 +41,7 @@ from fire.api.model import (
     type=str,
 )
 def opret_sag(projektnavn: str, sagsbehandler: str, beskrivelse: str, **kwargs) -> None:
-    """Registrer ny sag i databasen - husk anførelsestegn om sagsbehandlernavn"""
+    """Registrer ny sag i databasen"""
 
     if os.path.isfile(f"{projektnavn}.xlsx"):
         fire.cli.print(
@@ -99,5 +99,6 @@ def opret_sag(projektnavn: str, sagsbehandler: str, beskrivelse: str, **kwargs) 
         "Parametre": param,
     }
 
-    skriv_ark(projektnavn, resultater, "")
-    fire.cli.print("Færdig!")
+    if skriv_ark(projektnavn, resultater, ""):
+        fire.cli.print("Færdig! - åbner regneark for check.")
+        os.startfile(f"{projektnavn}.xlsx")


### PR DESCRIPTION
Tilpasset hjælpeteksten i opret_sag, så den passer med virkeligheden, og rettet regnearksoprettelsen, så nyskrevet regneark åbnes for manuel  kontrol.

Resolves #297