### PR TITLE
Bitsandbobs

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -53,6 +53,7 @@ class FireDb(object):
         """
         self.config = self._read_config()
 
+        self.db = db
         if db not in (None, "prod", "test", "ci"):
             raise ValueError(
                 "'db' skal være en af følgende: 'prod', 'test', 'ci' eller None"
@@ -496,6 +497,7 @@ class FireDb(object):
         """Konstruer connection-string til databasen."""
         if db is None:
             db = self.config.get("general", "default_connection")
+            self.db = db
 
         con = f"{db}_connection"
         username = self.config.get(con, "username")

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -18,76 +18,78 @@ from fire.api.model import (
 
 
 # ------------------------------------------------------------------------------
-@click.group()
+niv_help = f"""Nivellement: Arbejdsflow, beregning og analyse
+
+Underkommandoerne:
+
+    opret-sag
+
+    udtræk-revision
+
+    ilæg-revision
+
+    ilæg-nye-punkter
+
+    læs-observationer
+
+    regn
+
+    ilæg-observationer
+
+    ilæg-nye-koter
+
+    luk-sag
+
+definerer, i den anførte rækkefølge, nogenlunde arbejdsskridtene i et
+almindeligt opmålingsprojekt.
+
+OPRET-SAG registrerer sagen (projektet) i databasen og skriver det regneark,
+som bruges til at holde styr på arbejdet.
+
+UDTRÆK-REVISION udtrækker oversigt over eksisterende punkter i et område,
+til brug for punktrevision (herunder registrering af tabtgåede punkter).
+
+ILÆG-REVISION lægger opdaterede og nye punktattributter i databasen efter revision.
+
+ILÆG-NYE-PUNKTER lægger oplysninger om nyoprettede punkter i databasen, og tildeler
+bl.a. landsnumre til punkterne.
+
+LÆS-OBSERVATIONER læser råfilerne og skriver observationerne til regnearket så de
+er klar til brug i beregninger.
+
+REGN beregner nye koter til alle punkter, og genererer rapporter og
+visualiseringsmateriale.
+
+ILÆG-OBSERVATIONER lægger nye observationer i databasen.
+
+ILÆG-NYE-KOTER lægger nyberegnede koter i databasen.
+
+LUK-SAG arkiverer det afsluttende regneark og sætter sagens status til inaktiv.
+
+(i skrivende stund er ILÆG-REVISION og LUK-SAG endnu ikke implementeret, og
+ILÆG-NYE-PUNKTER står for en større overhaling)
+
+Eksempel:
+
+{click.style('fire niv opret-sag andeby_2020 Bxxxxxx "Vedligehold Andeby"', fg='green')}
+
+{click.style('fire niv ilæg-nye-punkter andeby_2020 Bxxxxxx', fg='green')}
+
+{click.style('fire niv læs-observationer andeby_2020', fg='green')}
+
+{click.style('fire niv regn andeby_2020', fg='green')}     <- kontrolberegning
+
+{click.style('fire niv regn andeby_2020', fg='green')}     <- endelig beregning
+
+{click.style('fire niv ilæg-observationer andeby_2020 Bxxxxxx', fg='green')}
+
+{click.style('fire niv ilæg-nye-koter andeby_2020 Bxxxxxx', fg='green')}
+
+"""
+
+
+@click.group(help=niv_help)
 def niv():
-    """Nivellement: Arbejdsflow, beregning og analyse
-
-    Underkommandoerne:
-
-        opret-sag
-
-        udtræk-revision
-
-        ilæg-revision
-
-        ilæg-nye-punkter
-
-        læs-observationer
-
-        regn
-
-        ilæg-observationer
-
-        ilæg-nye-koter
-
-        luk-sag
-
-    definerer, i den anførte rækkefølge, nogenlunde arbejdsskridtene i et
-    almindeligt opmålingsprojekt.
-
-    OPRET-SAG registrerer sagen (projektet) i databasen og skriver det regneark,
-    som bruges til at holde styr på arbejdet.
-
-    UDTRÆK-REVISION udtrækker oversigt over eksisterende punkter i et område,
-    til brug for punktrevision (herunder registrering af tabtgåede punkter).
-
-    ILÆG-REVISION lægger opdaterede og nye punktattributter i databasen efter revision.
-
-    ILÆG-NYE-PUNKTER lægger oplysninger om nyoprettede punkter i databasen, og tildeler
-    bl.a. landsnumre til punkterne.
-
-    LÆS-OBSERVATIONER læser råfilerne og skriver observationerne til regnearket så de
-    er klar til brug i beregninger.
-
-    REGN beregner nye koter til alle punkter, og genererer rapporter og
-    visualiseringsmateriale.
-
-    ILÆG-OBSERVATIONER lægger nye observationer i databasen.
-
-    ILÆG-NYE-KOTER lægger nyberegnede koter i databasen.
-
-    LUK-SAG arkiverer det afsluttende regneark og sætter sagens status til inaktiv.
-
-    (i skrivende stund er ILÆG-REVISION og LUK-SAG endnu ikke implementeret, og
-    ILÆG-NYE-PUNKTER står for en større overhaling)
-
-    Eksempel:
-
-    fire niv opret-sag andeby_2020 Bxxxxxx Testsag: Nyopmåling af Andeby
-
-    fire niv ilæg-nye-punkter andeby_2020 Bxxxxxx
-
-    fire niv læs-observationer andeby_2020
-
-    fire niv regn andeby_2020     <- kontrolberegning
-
-    fire niv regn andeby_2020     <- endelig beregning
-
-    fire niv ilæg-observationer andeby_2020 Bxxxxxx
-
-    fire niv ilæg-nye-koter andeby_2020 Bxxxxxx
-
-    """
     pass
 
 

--- a/fire/cli/niv/opret_sag.py
+++ b/fire/cli/niv/opret_sag.py
@@ -87,7 +87,7 @@ def opret_sag(projektnavn: str, sagsbehandler: str, beskrivelse: str, **kwargs) 
     )
     notater = pd.DataFrame([{"Dato": pd.Timestamp.now(), "Hvem": "", "Tekst": ""}])
     filoversigt = pd.DataFrame(columns=tuple(ARKDEF_FILOVERSIGT))
-    param = pd.DataFrame({"Navn": ["Major", "Minor", "Revision"], "Værdi": [0, 0, 0]})
+    param = pd.DataFrame({"Navn": ["Version"], "Værdi": fire.__version__})
 
     resultater = {
         "Projektforside": forside,
@@ -99,5 +99,8 @@ def opret_sag(projektnavn: str, sagsbehandler: str, beskrivelse: str, **kwargs) 
     }
 
     if skriv_ark(projektnavn, resultater, ""):
-        fire.cli.print("Færdig! - åbner regneark for check.")
-        os.startfile(f"{projektnavn}.xlsx")
+
+        # os.startfile() er kun tilgængelig på Windows
+        if "startfile" in dir(os):
+            fire.cli.print("Færdig! - åbner regneark for check.")
+            os.startfile(f"{projektnavn}.xlsx")

--- a/fire/cli/niv/opret_sag.py
+++ b/fire/cli/niv/opret_sag.py
@@ -87,7 +87,10 @@ def opret_sag(projektnavn: str, sagsbehandler: str, beskrivelse: str, **kwargs) 
     )
     notater = pd.DataFrame([{"Dato": pd.Timestamp.now(), "Hvem": "", "Tekst": ""}])
     filoversigt = pd.DataFrame(columns=tuple(ARKDEF_FILOVERSIGT))
-    param = pd.DataFrame({"Navn": ["Version"], "Værdi": fire.__version__})
+    param = pd.DataFrame(
+        columns=["Navn", "Værdi"],
+        data=[("Version", fire.__version__), ("Database", fire.cli.firedb.db)],
+    )
 
     resultater = {
         "Projektforside": forside,


### PR DESCRIPTION
Version og database skrives som parametre i projektfil. Eksempler i `fire niv --help` fremhæves med grøn, med henblik på at gøre livet nemmere for målerne der gerne vil kopiere eksempler og rette dem til fremfor at skrive kommandoerne selv:

<img width="629" alt="Screenshot 2021-02-07 at 18 43 44" src="https://user-images.githubusercontent.com/13132571/107156377-3d4a3000-697e-11eb-8031-a2725cd62c60.png">
