### PR TITLE
fire niv luk-sag

### DIFF
--- a/fire/api/_firedb_luk.py
+++ b/fire/api/_firedb_luk.py
@@ -17,7 +17,7 @@ from fire.api.model import (
 )
 
 
-def luk_sag(self, sag: Sag):
+def luk_sag(self, sag: Sag, commit: bool = True):
     """Sætter en sags status til inaktiv"""
     if not isinstance(sag, Sag):
         raise TypeError("'sag' er ikke en instans af Sag")
@@ -30,8 +30,10 @@ def luk_sag(self, sag: Sag):
         beskrivelse=current.beskrivelse,
         sag=sag,
     )
+
     self.session.add(new)
-    self.session.commit()
+    if commit:
+        self.session.commit()
 
 
 def luk_punkt(self, punkt: Punkt, sagsevent: Sagsevent, commit: bool = True):

--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -37,6 +37,7 @@ _default_options = [
         type=click.Choice(["prod", "test"]),
         default=None,
         callback=_set_database,
+        help="Vælg en specifik databaseforbindelse - default_connection i fire.ini bruges hvis intet vælges.",
     ),
     click.option(
         "-m",

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -66,8 +66,7 @@ ILÆG-NYE-KOTER lægger nyberegnede koter i databasen.
 
 LUK-SAG arkiverer det afsluttende regneark og sætter sagens status til inaktiv.
 
-(i skrivende stund er ILÆG-REVISION og LUK-SAG endnu ikke implementeret, og
-ILÆG-NYE-PUNKTER står for en større overhaling)
+(i skrivende stund står ILÆG-REVISION og ILÆG-NYE-PUNKTER for en større overhaling)
 
 Eksempel:
 
@@ -170,6 +169,10 @@ ARKDEF_SAG = {
     "uuid": str,
 }
 
+ARKDEF_PARAM = {
+    "Navn": str,
+    "Værdi": str,
+}
 
 # ------------------------------------------------------------------------------
 # Hjælpefunktioner
@@ -400,3 +403,4 @@ from .regn import regn
 from .ilæg_nye_koter import ilæg_nye_koter
 from .ilæg_nye_punkter import ilæg_nye_punkter
 from .netoversigt import netoversigt
+from .luk_sag import luk_sag

--- a/fire/cli/niv/luk_sag.py
+++ b/fire/cli/niv/luk_sag.py
@@ -1,0 +1,60 @@
+import os
+import os.path
+
+import click
+import pandas as pd
+import sys
+
+from fire import uuid
+import fire.cli
+
+from . import (
+    ARKDEF_PARAM,
+    find_faneblad,
+    find_sag,
+    niv,
+)
+
+
+@niv.command()
+@fire.cli.default_options()
+@click.argument(
+    "projektnavn",
+    nargs=1,
+    type=str,
+)
+def luk_sag(projektnavn: str, **kwargs) -> None:
+    """Luk sag i databasen"""
+
+    if not os.path.isfile(f"{projektnavn}.xlsx"):
+        fire.cli.print(
+            f"Filen '{projektnavn}.xlsx' eksisterer ikke - kan ikke lukke sag!"
+        )
+        sys.exit(1)
+
+    param = find_faneblad(projektnavn, "Parametre", ARKDEF_PARAM)
+    projekt_db = param.loc[param["Navn"] == "Database"]["Værdi"].to_string(index=False)
+
+    if projekt_db != fire.cli.firedb.db:
+        fire.cli.print(
+            f"{projektnavn} er kan ikke indsættes i {fire.cli.firedb.db}-databansen, da det er oprettet i {projekt_db}-databasen!"
+        )
+        sys.exit(1)
+
+    sag = find_sag(projektnavn)
+
+    fire.cli.firedb.luk_sag(sag, commit=False)
+    try:
+        # Indsæt alle objekter i denne session
+        fire.cli.firedb.session.flush()
+    except:
+        # rul tilbage hvis databasen smider en exception
+        fire.cli.firedb.session.rollback()
+    else:
+        if (
+            input(f"Er du sikker på at du vil lukke sagen {projektnavn}? ja/[nej]")
+            == "ja"
+        ):
+            fire.cli.firedb.session.commit()
+        else:
+            fire.cli.firedb.session.rollback()


### PR DESCRIPTION
Tilføjer en manglende brik:

```
$ fire niv luk-sag --help
Usage: fire niv luk-sag [OPTIONS] PROJEKTNAVN

  Luk sag i databasen

Options:
  --db [prod|test]  Vælg en specifik databaseforbindelse - default_connection
                    i fire.ini bruges hvis intet vælges.

  -m, --monokrom    Vis ikke farver i terminalen
  --debug           Vis debug output
  --help            Vis denne hjælp tekst
```