### PR TITLE
Refaktorering af 'fire niv ilæg-nye-punkter'

### DIFF
--- a/fire/api/firedb.py
+++ b/fire/api/firedb.py
@@ -199,7 +199,6 @@ class FireDb(object):
         landsnumre = {}
         for distrikt, pkt_ider in distrikt_punkter.items():
             brugte_løbenumre = self._løbenumre_i_distrikt(distrikt)
-
             for punktid in pkt_ider:
                 for kandidat in self._generer_tilladte_løbenumre(punkttyper[punktid]):
                     if kandidat in brugte_løbenumre:
@@ -359,7 +358,7 @@ class FireDb(object):
                 """
         )
 
-        return [løbenummer for løbenummer in self.session.execute(sql)]
+        return [løbenummer[0] for løbenummer in self.session.execute(sql)]
 
     def _hent_konfiguration(self):
         return (

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -79,6 +79,8 @@ Eksempel:
 
 {grøn('fire niv opret-sag andeby_2020 "Vedligehold Andeby"')}
 
+{grøn('fire niv udtræk-revision andeby_2020 K-99 102-08')}
+
 {grøn('fire niv ilæg-nye-punkter andeby_2020')}
 
 {grøn('fire niv læs-observationer andeby_2020')}
@@ -239,7 +241,8 @@ def skriv_ark(
                         writer, sheet_name=r, encoding="utf-8", index=False
                     )
             if suffix == "-resultat":
-                os.startfile(f"{projektnavn}-resultat.xlsx")
+                if "startfile" in dir(os):
+                    os.startfile(f"{projektnavn}-resultat.xlsx")
             return True
         except Exception as ex:
             fire.cli.print(
@@ -380,6 +383,21 @@ def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
             },
         }
         yield feature
+
+
+def bekræft2(spørgsmål: str) -> bool:
+    """
+    Bed bruger om at tage stilling til spørgsmålet.
+
+    Erstatning for bekræft().
+    """
+    fire.cli.print(f"{spørgsmål} (ja/NEJ):")
+    svar = input()
+    if svar in ("ja", "JA", "Ja"):
+        if input("Gentag svar for at bekræfte (ja/NEJ)\n") in ("ja", "JA", "Ja"):
+            return True
+
+    return False
 
 
 def bekræft(spørgsmål: str, alvor: bool, test: bool) -> Tuple[bool, bool]:

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -388,8 +388,6 @@ def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
 def bekræft2(spørgsmål: str) -> bool:
     """
     Bed bruger om at tage stilling til spørgsmålet.
-
-    Erstatning for bekræft().
     """
     fire.cli.print(f"{spørgsmål} (ja/NEJ):")
     svar = input()


### PR DESCRIPTION

Hovedformålet er at tage `firedb.tilknyt_landsnumre()` i brug, men derudover
indføres også en mere robust indsættelse af data og en ny metode til at
lade brugeren tage stilling til indsættelse eller ej.

Data indsættes nu i databasen løbende med henblik på at lade databasen
afsløre eventuelle fejlbehæftede data. Først allersidst, efter
brugerbekræftelse, committes til databasen. Herved sikres at data
indsættes korrekt ved afslutning af programmet.

Programparametrene `--alvor` og `--test` er fjernet, da det med `--db` nu er
muligt at specificere om man vil indsætte i test eller prod database.
Desuden er en ny bekræftelsesprompt indført, der spørger brugeren om hen
er sikker på at n punkter skal indsættes i [test|prod]-databasen. For at
indsætte data skal der svares "ja" to gange. Dette burde sikre
tilstrækkelig betænkningstid hos brugeren så der sjældent laves
fejltagelser.

Eksempel på programkørsel:

<img width="651" alt="Screenshot 2021-02-09 at 18 39 04" src="https://user-images.githubusercontent.com/13132571/107404124-3bab7400-6b06-11eb-8096-eed05afe8ca3.png">

Bemærk at der ikke længere skrives hvilket punkt der aktuelt arbejdes på. Dette skyldes at behandling af punkter og punktinfo nu sker i to separate løkker og det støjer lidt rigeligt hvis begge løkker skal snakke højt om hvad de gør.

Closes #306 