### PR TITLE
Færdiggør fire niv ilæg-revision

### DIFF
--- a/fire/cli/niv/ilæg_revision.py
+++ b/fire/cli/niv/ilæg_revision.py
@@ -1,30 +1,19 @@
 import sys
 import getpass
-from datetime import datetime
-from math import trunc, isnan, radians
-from time import sleep
 
 import click
 import pandas as pd
-from pyproj import Proj
-from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
 from fire import uuid
 from fire.api.model import (
     EventType,
-    GeometriObjekt,
-    Koordinat,
-    Point,
-    Punkt,
     PunktInformation,
-    PunktInformationType,
     PunktInformationTypeAnvendelse,
     Sag,
     Sagsevent,
     SagseventInfo,
-    Srid,
 )
 
 from . import (
@@ -32,7 +21,6 @@ from . import (
     bekræft,
     find_faneblad,
     find_sag,
-    find_sagsgang,
     niv,
 )
 
@@ -82,7 +70,6 @@ def ilæg_revision(
 ) -> None:
     """Læg reviderede punktdata i databasen"""
     sag = find_sag(projektnavn)
-    sagsgang = find_sagsgang(projektnavn)
 
     fire.cli.print("Lægger punktrevisionsarbejde i databasen")
 
@@ -96,7 +83,6 @@ def ilæg_revision(
     revision = find_faneblad(f"{projektnavn}-revision", "Revision", ARKDEF_REVISION)
     revision = revision.replace("nan", "")
     bemærkning = " ".join(bemærkning)
-    opdateret = pd.DataFrame(columns=list(ARKDEF_REVISION))
 
     # Udfyld udeladte identer
     punkter = list(revision["Punkt"])
@@ -108,18 +94,8 @@ def ilæg_revision(
         punkter[i] = udfyldningsværdi
     revision["Punkt"] = punkter
 
-    # Find alle punkter, der skal nyoprettes
-    oprettelse = revision.query(f"Attribut == 'Opret'")
-    for row in oprettelse.to_dict("records"):
-        if row["id"] == -1:
-            continue
-        fire.cli.print(f"Opretter nyt punkt: {row['Punkt']}")
-        if alvor:
-            opret_punkt(row["Punkt"], row["Ny værdi"], sag)
-    revision = revision.query(f"Attribut != 'Opret'")
-
     # Find alle lokationskoordinater, der skal korrigeres
-    lokation = revision.query(f"Attribut == 'Lokation'")
+    lokation = revision.query(f"Attribut == 'OVERVEJ:lokation'")
     lokation = lokation.query(f"`Ny værdi` != ''")
     for row in lokation.to_dict("records"):
         fire.cli.print(
@@ -127,112 +103,7 @@ def ilæg_revision(
         )
         if alvor:
             pass  # refaktor af opret_punkt(row["Punkt"], row["Ny værdi"], sag)
-    revision = revision.query(f"Attribut != 'Lokation'")
-
-    # Find alle koordinater, der skal oprettes
-
-    # Først skal vi bruge alle gyldige koordinatsystemnavne
-    srider = fire.cli.firedb.hent_srider()
-    sridnavne = [srid.name.upper() for srid in srider]
-
-    # Så itererer vi over hele rammen og ignorerer ikke-koordinaterne
-    til_registrering = []
-    opdaterede_punkter = []
-    koordinatoprettelsestekst = str()
-    for r in revision.to_dict("records"):
-        sridnavn = r["Attribut"].upper()
-        if sridnavn not in sridnavne:
-            continue
-        try:
-            koord = [float(k.replace(",", ".")) for k in r["Ny værdi"].split()]
-        except ValueError as ex:
-            fire.cli.print(
-                f"Slemt koordinatudtryk:\n{'    '.join(r['Ny værdi'])}\n{ex}"
-            )
-            sys.exit(1)
-
-        # Oversæt NaN til None
-        koord = [None if isnan(k) else k for k in koord]
-
-        # Tæt-på-kopi af kode fra "niv/ilæg_nye_koter.py". Her bør mediteres og overvejes
-        # hvordan denne opgave kan parametriseres på en rimeligt generel måde, så den kan
-        # udstilles i et "højniveau-API"
-        srid = fire.cli.firedb.hent_srid(sridnavn)
-        registreringstidspunkt = func.current_timestamp()
-        sagsevent = Sagsevent(
-            sag=sag, id=uuid(), eventtype=EventType.KOORDINAT_BEREGNET
-        )
-
-        # Undgå forsøg på at læse punkter der endnu ikke er skrevet til databasen:
-        # Ved testkørsler bruger vi dummypunkt 00009 fra det ikke-eksisterende
-        # opmålingsdistrikt 9-09. Ved endelige kørsler har vi lige lagt punkterne
-        # i databasen ovenfor, så her kan vi bruge de faktiske punktnavne.
-        if not alvor:
-            punkt = fire.cli.firedb.hent_punkt("9-09-00009")
-        else:
-            punkt = fire.cli.firedb.hent_punkt(r["Punkt"])
-        opdaterede_punkter.append(r["Punkt"])
-
-        # Det er ikke helt så nemt som i C at oversætte decimal-år til datetime
-        if koord[3] is None:
-            tid = None
-        else:
-            år = trunc(koord[3])
-            rest = koord[3] - år
-            startdato = datetime(år, 1, 1)
-            årlængde = datetime(år + 1, 1, 1) - startdato
-            tid = startdato + rest * årlængde
-
-        koordinat = Koordinat(
-            srid=srid,
-            punkt=punkt,
-            x=koord[0],
-            y=koord[1],
-            z=koord[2],
-            t=tid,
-            sx=koord[4],
-            sy=koord[5],
-            sz=koord[6],
-        )
-        til_registrering.append(koordinat)
-
-        # I Grønland er vi nødt til at duplikere geografiske koordinater til UTM24,
-        # da Oracles indbyggede UTM-rutine er for ringe til at vi kan generere
-        # udstillingskoordinater on-the-fly.
-        if sridnavn == "EPSG:4909" or sridnavn == "EPSG:4747":
-            srid_utm24 = fire.cli.firedb.hent_srid("EPSG:3184")
-            utm24 = Proj("proj=utm zone=24 ellps=GRS80", preserve_units=False)
-            x, y = utm24(koord[0], koord[1])
-            koordinat = Koordinat(
-                srid=srid_utm24,
-                punkt=punkt,
-                x=x,
-                y=y,
-                z=None,
-                t=tid,
-                sx=koord[4],
-                sy=koord[5],
-                sz=None,
-            )
-            til_registrering.append(koordinat)
-
-    n = len(opdaterede_punkter)
-    if n > 0:
-        punktnavne = sorted(list(set(opdaterede_punkter)))
-        if len(punktnavne) > 10:
-            punktnavne[9] = "..."
-            punktnavne[10] = punktnavne[-1]
-            punktnavne = punktnavne[0:10]
-        koordinatoprettelsestekst = (
-            f"Opdatering af {n} koordinater til {', '.join(punktnavne)}"
-        )
-        sagseventinfo = SagseventInfo(beskrivelse=koordinatoprettelsestekst)
-        sagsevent.sagseventinfos.append(sagseventinfo)
-        sagsevent.koordinater = til_registrering
-        if alvor:
-            fire.cli.firedb.indset_sagsevent(sagsevent)
-
-    # Så tager vi fat på punktinformationerne
+    revision = revision.query(f"Attribut != 'OVERVEJ:lokation'")
 
     # Find identer for alle punkter, der indgår i revisionen
     identer = tuple(sorted(set(revision["Punkt"]) - set(["nan", ""])))
@@ -252,7 +123,6 @@ def ilæg_revision(
         # Hent punkt og alle relevante punktinformationer i databasen
         # Håndter punkter der endnu ikke er persisterede under test.
         #
-        # Her er det lidt sværere end for koordinaternes vedkommende:
         # Ved opdatering af eksisterende punkter vil vi gerne checke
         # infonøglerne, så vi er nødt til at hente det faktiske punkt,
         # med tilørende infonøgler, fra databasen - alvor eller ej
@@ -279,8 +149,6 @@ def ilæg_revision(
         rev = revision.query(f"Punkt == '{ident}' and Attribut != 'Opret'")
 
         for r in rev.to_dict("records"):
-            if r["Attribut"] in sridnavne:
-                continue
             if r["id"] == 999999:
                 continue
             if r["id"] == -1:
@@ -333,7 +201,7 @@ def ilæg_revision(
                     tekst = r["Ny værdi"]
                     if tekst is None or tekst == "":
                         fire.cli.print(
-                            f"    ADVARSEL: Tom tekst anført for {pitnavn} [{ex}].",
+                            f"    ADVARSEL: Tom tekst anført for {pitnavn}.",
                             fg="yellow",
                             bold=True,
                         )
@@ -417,106 +285,11 @@ def ilæg_revision(
         fire.cli.print(
             f"TESTEDE punktrevision for '{projektnavn}':", fg="yellow", bold=True
         )
-        if koordinatoprettelsestekst != "":
-            fire.cli.print(f"    * {koordinatoprettelsestekst}")
         fire.cli.print(f"    * {opret_tekst}")
         fire.cli.print(f"    * {sluk_tekst}")
         fire.cli.print(f"    * {ret_tekst}")
         fire.cli.print(f"Ingen data lagt i FIRE-databasen", fg="yellow")
         sys.exit(0)
-
-
-def opret_punkt(ident: str, lokation: str, sag: Sag):
-    """Opret nyt punkt i databasen, ud fra minimumsinformationsmængder."""
-
-    lok = lokation.split()
-    assert len(lok) in (
-        2,
-        4,
-    ), f"Lokation '{lokation}' matcher ikke format: 55.443322 [N] 12.345678 [Ø]."
-    if len(lok) == 2:
-        lok = [lok[0], "", lok[1], ""]
-    try:
-        e = float(lok[2])
-        n = float(lok[0])
-    except ValueError as ex:
-        fire.cli.print(f"Ikke-numerisk lokationskoordinat anført: {lokation} ({ex})")
-        sys.exit(1)
-
-    # Håndter verdenshjørner Nn/ØøEe/VvWw/Ss
-    if lok[1].upper() == "S":
-        n = -n
-    if lok[3].upper() in ("W", "V"):
-        e = -e
-
-    # Regionen kan detekteres alene ud fra længdegraden, hvis vi holder os til
-    # {DK, EE, FO, GL}. EE er dog ikke understøttet her: Hvis man forsøger at
-    # oprette nye estiske punkter vil de blive tildelt region DK
-    if e > 0:
-        region = "REGION:DK"
-    elif e < -11:
-        region = "REGION:GL"
-    else:
-        region = "REGION:FO"
-
-    # Hvis ident har regionspræfiks, så skræller vi det af og håndterer det separat
-    region_ident = ident.split()
-    if len(region_ident) == 2:
-        assert region_ident[0] in (
-            "DK",
-            "FO",
-            "GL",
-        ), f"Ukendt regionspræfiks: {region_ident[0]}"
-        ident = region_ident[1]
-
-    prefix = {"REGION:DK": "", "REGION:FO": "FO  ", "REGION:GL": "GL  "}
-
-    if 3 == len(ident.split("-")):
-        identtype = "IDENT:landsnr"
-    elif 4 == len(ident) and not ident.isnumeric():
-        identtype = "IDENT:GNSS"
-    elif ident.startswith("G.M."):
-        identtype = "IDENT:GI"
-    elif ident.startswith("G.I."):
-        identtype = "IDENT:GI"
-    else:
-        if ident.isnumeric():
-            identtype = "IDENT:station"
-        else:
-            identtype = "IDENT:ekstern"
-
-    p = Punkt(id=uuid())
-    go = GeometriObjekt()
-    go.geometri = Point([e, n])
-    p.geometriobjekter.append(go)
-
-    se = Sagsevent(sag=sag, id=uuid(), eventtype=EventType.PUNKT_OPRETTET)
-    si = SagseventInfo(beskrivelse=f"opret {ident}")
-    se.sagseventinfos.append(si)
-    se.punkter.append(p)
-    fire.cli.firedb.indset_sagsevent(se)
-
-    # indsæt ident
-    pit = fire.cli.firedb.hent_punktinformationtype(identtype)
-    if pit is None:
-        fire.cli.print(f"Kan ikke finde identtype '{identtype}'")
-        sys.exit(1)
-    pi = PunktInformation(infotype=pit, punkt=p, tekst=f"{prefix[region]}{ident}")
-    se = Sagsevent(sag=sag, id=uuid(), eventtype=EventType.PUNKTINFO_TILFOEJET)
-    si = SagseventInfo(beskrivelse=f"tilpas {ident}")
-    se.sagseventinfos.append(si)
-    fire.cli.firedb.indset_punktinformation(se, pi)
-
-    # indsæt region
-    pit = fire.cli.firedb.hent_punktinformationtype(region)
-    if pit is None:
-        fire.cli.print(f"Kan ikke finde region '{region}'")
-        sys.exit(1)
-    pi = PunktInformation(infotype=pit, punkt=p)
-    se = Sagsevent(sag=sag, id=uuid(), eventtype=EventType.PUNKTINFO_TILFOEJET)
-    si = SagseventInfo(beskrivelse=f"tilpas {ident}")
-    se.sagseventinfos.append(si)
-    fire.cli.firedb.indset_punktinformation(se, pi)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Okay, jeg ved ikke om ambitionen er at færdiggøre `fire niv ilæg-revision`, men i hvert fald har jeg forsøgt at forstå hvad programmet bør gøre og faktisk gør. Jeg tror ikke de to flugter med hinanden. I den nuværende implementering gøres der en del mht oprettelse af punkter og koordinater. For mig ser det ud til at være et første forsøg på hvad denne del af niv-pakken skulle kunne, og så er der efterfølgende blevet justeret på konceptet uden koden har fulgt med. Workshopdokumentationen omtaler i hvert fald ikke oprettelse af punkter og justering af koordinater i forbindelse med revision (og det håndteres jo også andetsteds, hhv `fire niv ilæg-nye-punkter` og `fire niv ilæg-nye-koter`).

SÅ, dette PR er for nuværende primært et forsøg på at forstå hvad intentionen med `fire niv ilæg-revision` er. Til at illustrere det har jeg fjernet al den kode, jeg baseret på ovenstående, tror er blevet overflødig. Har jeg ramt rigtigt, @busstoptaktik ?

Hvis jeg ellers har ramt rigtigt med lugejernet, så er der herefter nogle flere ting der skal tages hul på:

1. Håndter OVERVEJ:lokation
2. Generer væsentligt færre sagsevents (nu laves en pr. punktinfo der ændres/oprettese/slettes)
3. benyt den nye `bekræft2()`-funktion på samme måde som i `fire niv ilæg-nye-punkter`
4. sikkert andet jeg ikke har opdaget endnu...