### PR TITLE
Undgå brug af uinitialiseret variabel 'datumstabilt'

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -80,6 +80,7 @@ def udtræk_revision(
     punkter = fire.cli.firedb.session.query(Punkt).from_statement(stmt).all()
 
     for punkt in punkter:
+        datumstabilt = False
         ident = punkt.ident
         fire.cli.print(f"Punkt: {ident}")
 


### PR DESCRIPTION
Løser nedenstående fejl
```
(fire) F:\GRF\Data\GEO\BC\Niv_Opgaver\2021\test_udtræk>fire niv opret-sag 2021_revision "Revi 123-09 123-11 123-12"
Sags/projekt-navn: 2021_revision  (cb3674c9-dd3e-4992-a24c-e99892eadd2a)
Sagsbehandler:     B012858
Beskrivelse:       Revi 123-09 123-11 123-12
Opretter ny sag i test-databasen - er du sikker?  (ja/NEJ):
ja
Gentag svar for at bekræfte (ja/NEJ)
ja
Sag '2021_revision' oprettet
Skriver sagsregneark '2021_revision.xlsx'
Filen '2021_revision.xlsx' findes ikke.
Skriver: {'Sagsgang', 'Filoversigt', 'Nyetablerede punkter', 'Notater', 'Projektforside', 'Parametre'}
Til filen '2021_revision.xlsx'
Færdig! - åbner regneark for check.

(fire) F:\GRF\Data\GEO\BC\Niv_Opgaver\2021\test_udtræk>fire niv udtræk-revision 2021_revision 123-11 123-12 123-09
Punkt: 123-09-09055
Punkt: THOJ
Traceback (most recent call last):
  File "C:\Users\b012858\Miniconda3\envs\fire\Scripts\fire-script.py", line 33, in <module>
    sys.exit(load_entry_point('fire', 'console_scripts', 'fire')())
  File "C:\Users\b012858\Miniconda3\envs\fire\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\b012858\Miniconda3\envs\fire\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "C:\Users\b012858\Miniconda3\envs\fire\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\b012858\Miniconda3\envs\fire\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\b012858\Miniconda3\envs\fire\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\b012858\Miniconda3\envs\fire\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\fire\fire\fire\cli\niv\_udtræk_revision.py", line 136, in udtræk_revision
    pos = 1 if datumstabilt else 0
UnboundLocalError: local variable 'datumstabilt' referenced before assignment

(fire) F:\GRF\Data\GEO\BC\Niv_Opgaver\2021\test_udtræk>
```