### PR TITLE
Korriger beregningsstatistikelementer

### DIFF
--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -142,7 +142,7 @@ def spredning(
     if "NUL" == observationstype.upper():
         return 0
 
-    opstillingsafhængig = antal_opstillinger * (centreringsspredning_i_mm ** 2)
+    opstillingsafhængig = sqrt(antal_opstillinger * (centreringsspredning_i_mm ** 2))
 
     if "MTL" == observationstype.upper():
         afstandsafhængig = afstandsafhængig_spredning_i_mm * afstand_i_m / 1000
@@ -181,7 +181,7 @@ def gama_beregning(
             f"<network angles='left-handed' axes-xy='en' epoch='0.0'>\n"
             f"<parameters\n"
             f"    algorithm='gso' angles='400' conf-pr='0.95'\n"
-            f"    cov-band='0' ellipsoid='grs80' latitude='55.7' sigma-act='apriori'\n"
+            f"    cov-band='0' ellipsoid='grs80' latitude='55.7' sigma-act='aposteriori'\n"
             f"    sigma-apr='1.0' tol-abs='1000.0'\n"
             f"/>\n\n"
             f"<description>\n"


### PR DESCRIPTION
I funktionen 'spredning' var centreringsvariansen, frem for
centreringsspredningen, anvendt til beregning af den totale
spredning. Dette er nu korrigeret, så det er to spredninger,
der summeres til en samlet spredning med brug af hypot().

Samtidig er GNU Gama parameteren 'sigma-act' rettet fra
sigma-act='apriori' til
sigma-act='aposteriori'.

I testberegninger er den samlede effekt lille: Sprednings-
estimatet stiger med ca. 10%, mens koterne udviser ændringer
på mikrometerniveau.

Resolves #355