### PR TITLE
Beskriv afhængighedsopdatering i HOWTORELEASE

### DIFF
--- a/HOWTORELEASE.md
+++ b/HOWTORELEASE.md
@@ -4,9 +4,12 @@ FIRE følger [Semantisk Versionering](https://semver.org/).
 
 Følg disse skridt i forbindelse med en ny release:
 
+- Hvis der *ikke* er tale om en patch-release:
+  - Test FIRE med opdaterede versioner af alle afhængigheder, så `environment.yml` og `environment-dev.yml` reflekterer "seneste anvendelige version" af hver afhængighed.
+  - `git commit -a -m "Opdater afhængigheder"`
 - Opdater versionsnummer i `fire/__init__.py`
 - Commit ændring af versionsnummer
-- Tag dette commit med versionsnummere: `git tag fire-x.y.z` + `git push --tags`
+- Tag dette commit med versionsnumre: `git tag fire-x.y.z` + `git push --tags`
 - Luk milestone på GitHub, opret ny til næste nummer i rækken
 - Send mail til kolleger om at der er en ny version klar. Inkluder brugervendt changelog.
-- Hvis denne release er første en ny major eller minor release oprettes en ny branch til håndtering af bug fixes: `git checkout -b x.y` + `git push origin x.y`
+- Hvis denne release er en ny major eller minor release oprettes en ny branch til håndtering af bug fixes: `git checkout -b x.y` + `git push origin x.y`


### PR DESCRIPTION
Absolut minimal beskrivelse, som sandsynligvis kan fjernes igen hvis vi indfører håndtering via CI.

Resolves #304