### PR TITLE
Håndter beregning af projekt mere end et nivellementsnet

### DIFF
--- a/fire/cli/niv/_netoversigt.py
+++ b/fire/cli/niv/_netoversigt.py
@@ -65,8 +65,7 @@ def netanalyse(
     # Opbyg net ud fra de fastholdte punkter, eller ud fra det mest observerede
     # punkt, hvis der endnu ikke er fastholdte punkter (dette er fx tilfældet
     # umiddelbart efter indlæsning af observationer)
-    punktoversigt = punktoversigt.replace("nan", "")
-    fastholdte = tuple(punktoversigt[punktoversigt["Fasthold"] != ""]["Punkt"])
+    fastholdte = tuple(punktoversigt[punktoversigt["Fasthold"] == "x"]["Punkt"])
     if 0 == len(fastholdte):
         alle_obs = list(observationer["Fra"]) + list(observationer["Til"])
         c = Counter(alle_obs)

--- a/fire/cli/niv/_netoversigt.py
+++ b/fire/cli/niv/_netoversigt.py
@@ -1,3 +1,4 @@
+import sys
 from collections import Counter
 from typing import Dict, List, Set, Tuple
 
@@ -86,6 +87,20 @@ def netgraf(
     assert len(fastholdte_punkter) > 0, "Netanalyse kræver mindst et fastholdt punkt"
     # Initialiser
     net = {}
+
+    # Sanity check af fastholdte punkter versus tilgængelige observationer
+    afbryd = False
+    for fastholdt_punkt in fastholdte_punkter:
+        if not fastholdt_punkt in alle_punkter:
+            fire.cli.print(
+                f"FEJL: Observation(er) for fastholdt punkt {fastholdt_punkt} er slukket eller mangler",
+                fg="white",
+                bg="red",
+            )
+            afbryd = True
+    if afbryd:
+        sys.exit(1)
+
     for punkt in alle_punkter:
         net[punkt] = set()
 

--- a/fire/cli/niv/_netoversigt.py
+++ b/fire/cli/niv/_netoversigt.py
@@ -65,6 +65,8 @@ def netanalyse(
     # punkt, hvis der endnu ikke er fastholdte punkter (dette er fx tilfældet
     # umiddelbart efter indlæsning af observationer)
     fastholdte = tuple(punktoversigt[punktoversigt["Fasthold"].notnull()]["Punkt"])
+    print("Fastholdte punkter:")
+    print(fastholdte)
     if 0 == len(fastholdte):
         alle_obs = list(observationer["Fra"]) + list(observationer["Til"])
         c = Counter(alle_obs)

--- a/fire/cli/niv/_netoversigt.py
+++ b/fire/cli/niv/_netoversigt.py
@@ -66,8 +66,6 @@ def netanalyse(
     # umiddelbart efter indlæsning af observationer)
     punktoversigt = punktoversigt.replace("nan", "")
     fastholdte = tuple(punktoversigt[punktoversigt["Fasthold"] != ""]["Punkt"])
-    print("Fastholdte punkter:")
-    print(fastholdte)
     if 0 == len(fastholdte):
         alle_obs = list(observationer["Fra"]) + list(observationer["Til"])
         c = Counter(alle_obs)
@@ -95,6 +93,26 @@ def netgraf(
     for fra, til in zip(observationer["Fra"], observationer["Til"]):
         net[fra].add(til)
         net[til].add(fra)
+
+    # Undersøg om der er nettet består af flere ikke-sammenhængende subnet.
+    # Skriv advarsel hvis ikke der er mindste et fastholdt punkt i hvert
+    # subnet.
+    subnet = analyser_subnet(net)
+    if len(subnet) > 1:
+        fastholdte_i_subnet = [None for _ in subnet]
+        for i, subnet_ in enumerate(subnet):
+            for subnetpunkt in subnet_:
+                if subnetpunkt in fastholdte_punkter:
+                    fastholdte_i_subnet[i] = subnetpunkt
+                    continue
+
+        if None in fastholdte_i_subnet:
+            fire.cli.print("ADVARSEL: Manglende fastholdt punkt i mindst et subnet! Forslag til fastholdte punkter i hvert subnet:", bg="yellow", fg="black")
+            for i, subnet_ in enumerate(subnet):
+                if fastholdte_i_subnet[i]:
+                    fire.cli.print(f"  Subnet {i}: {fastholdte_i_subnet[i]}", fg="green")
+                else:
+                    fire.cli.print(f"  Subnet {i}: {subnet_[0]}", fg="red")
 
     # Tilføj forbindelser fra alle fastholdte punkter til det første fastholdte punkt
     udgangspunkt = fastholdte_punkter[0]
@@ -181,3 +199,30 @@ def path_to_origin(
             if newpath:
                 return newpath
     return None
+
+def analyser_subnet(net):
+    """
+    Find selvstændige net i et større net
+
+    Med inspiration fra https://www.geeksforgeeks.org/connected-components-in-an-undirected-graph/
+    """
+    def depth_first_search(net, visited, vertex, subnet):
+        visited[vertex] = True
+        subnet.append(vertex)
+
+        for adjacent_vertex in net[vertex]:
+            if not visited[adjacent_vertex]:
+                net, visited, vertex, subnet = depth_first_search(net, visited, adjacent_vertex, subnet)
+
+        return net, visited, vertex, subnet
+
+
+    visited = {vertex: False for vertex in net.keys()}
+    connected_vertices = []
+    for vertex in net.keys():
+        if not visited[vertex]:
+            subnet = []
+            net, visited, vertex, subnet = depth_first_search(net, visited, vertex, subnet)
+            connected_vertices.append(subnet)
+
+    return connected_vertices

--- a/fire/cli/niv/_netoversigt.py
+++ b/fire/cli/niv/_netoversigt.py
@@ -64,7 +64,8 @@ def netanalyse(
     # Opbyg net ud fra de fastholdte punkter, eller ud fra det mest observerede
     # punkt, hvis der endnu ikke er fastholdte punkter (dette er fx tilfældet
     # umiddelbart efter indlæsning af observationer)
-    fastholdte = tuple(punktoversigt[punktoversigt["Fasthold"].notnull()]["Punkt"])
+    punktoversigt = punktoversigt.replace("nan", "")
+    fastholdte = tuple(punktoversigt[punktoversigt["Fasthold"] != ""]["Punkt"])
     print("Fastholdte punkter:")
     print(fastholdte)
     if 0 == len(fastholdte):

--- a/fire/cli/niv/_netoversigt.py
+++ b/fire/cli/niv/_netoversigt.py
@@ -107,10 +107,16 @@ def netgraf(
                     continue
 
         if None in fastholdte_i_subnet:
-            fire.cli.print("ADVARSEL: Manglende fastholdt punkt i mindst et subnet! Forslag til fastholdte punkter i hvert subnet:", bg="yellow", fg="black")
+            fire.cli.print(
+                "ADVARSEL: Manglende fastholdt punkt i mindst et subnet! Forslag til fastholdte punkter i hvert subnet:",
+                bg="yellow",
+                fg="black",
+            )
             for i, subnet_ in enumerate(subnet):
                 if fastholdte_i_subnet[i]:
-                    fire.cli.print(f"  Subnet {i}: {fastholdte_i_subnet[i]}", fg="green")
+                    fire.cli.print(
+                        f"  Subnet {i}: {fastholdte_i_subnet[i]}", fg="green"
+                    )
                 else:
                     fire.cli.print(f"  Subnet {i}: {subnet_[0]}", fg="red")
 
@@ -200,29 +206,34 @@ def path_to_origin(
                 return newpath
     return None
 
+
 def analyser_subnet(net):
     """
     Find selvstændige net i et større net
 
     Med inspiration fra https://www.geeksforgeeks.org/connected-components-in-an-undirected-graph/
     """
+
     def depth_first_search(net, visited, vertex, subnet):
         visited[vertex] = True
         subnet.append(vertex)
 
         for adjacent_vertex in net[vertex]:
             if not visited[adjacent_vertex]:
-                net, visited, vertex, subnet = depth_first_search(net, visited, adjacent_vertex, subnet)
+                net, visited, vertex, subnet = depth_first_search(
+                    net, visited, adjacent_vertex, subnet
+                )
 
         return net, visited, vertex, subnet
-
 
     visited = {vertex: False for vertex in net.keys()}
     connected_vertices = []
     for vertex in net.keys():
         if not visited[vertex]:
             subnet = []
-            net, visited, vertex, subnet = depth_first_search(net, visited, vertex, subnet)
+            net, visited, vertex, subnet = depth_first_search(
+                net, visited, vertex, subnet
+            )
             connected_vertices.append(subnet)
 
     return connected_vertices

--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import webbrowser
+from pathlib import Path
 from math import hypot, sqrt
 from typing import Dict, List, Set, Tuple
 
@@ -182,7 +183,6 @@ def gama_beregning(
         gamafil.write("<height-differences>\n")
         for obs in observationer.itertuples(index=False):
             if obs.Sluk == "x":
-                fire.cli.print(f"Slukket {obs}")
                 continue
             gamafil.write(
                 f"<dh from='{obs.Fra}' to='{obs.Til}' "
@@ -217,6 +217,14 @@ def gama_beregning(
         ]
     )
     if ret.returncode:
+        if not Path(f"{projektnavn}-resultat.xml").is_file():
+            fire.cli.print(
+                "FEJL: Beregning ikke gennemført. Kontroller om nettet er sammenhængende, og ved flere net om der mangler fastholdte punkter.",
+                bg="red",
+                fg="white",
+            )
+            sys.exit(1)
+
         fire.cli.print(
             f"Check {projektnavn}-resultat-{beregningstype}.html", bg="red", fg="white"
         )


### PR DESCRIPTION
Der er flere ting der kommer i røven af hinanden. Lang udredning herunder, primært for at jeg selv kan finde hoved og hale i det hele. Der kommer et par spørgsmål til sidst :-)

Fejlen manifesterer sig først og fremmest ved at Gama ikke producerer en output fil når man forsøger at lave en beregning på flere subnet på en gang, hvor der kun er et enkelt fastholdt punkt fordelt på de *n* subnet. Se herunder:
```
>fire niv regn 2018_KDI_RIKO
Så regner vi
Analyserer net
Fastholder 1 og beregner nye koter for 186 punkter
Check 2018_KDI_RIKO-resultat-kontrol.html
Traceback (most recent call last):
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\Scripts\fire-script.py", line 33, in <module>
    sys.exit(load_entry_point('fire', 'console_scripts', 'fire')())
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\b012349\AppData\Local\Continuum\miniconda3\envs\fire-dev\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\dev\fire\fire\cli\niv\_regn.py", line 81, in regn
    projektnavn, observationer, punktoversigt, estimerede_punkter, kontrol
  File "c:\dev\fire\fire\cli\niv\_regn.py", line 225, in gama_beregning
    with open(f"{projektnavn}-resultat.xml") as resultat:
FileNotFoundError: [Errno 2] No such file or directory: '2018_KDI_RIKO-resultat.xml'
```
[2018_KDI_RIKO.xlsx](https://github.com/Kortforsyningen/FIRE/files/6076871/2018_KDI_RIKO.xlsx) er brugt som input. 

Fejlen ovenfor kan fx løses som i ff2ec9e84227ed63cdfddfdff27bba397b542682. Hvilket giver output i stil med:

```
>fire niv regn 2018_KDI_RIKO
Så regner vi
Analyserer net
Fastholder 1 og beregner nye koter for 186 punkter
FEJL: Beregning ikke gennemført. Kontroller om nettet er sammenhængende, og ved flere net om der mangler fastholdte punkter.
```

Dykker man dybere i koden vil man opdage at koden tror at samtlige punkter i nettet er fastholdte. Det afsløres med a614962 at det sker:

```
>fire niv regn 2018_KDI_RIKO
Så regner vi
('118-02-09003', '118-02-09016', '118-02-09021', '118-02-09024', '118-02-09025', '118-04-00817', '118-04-00821', '118-04-00822', '118-04-00823', '118-04-00856', '118-04-00857', '118-04-00890', '118-04-00891', '118-04-00892', '118-04-09004', '118-04-09005', '118-04-09007', '118-04-09015', '118-04-09019', '118-04-09027', '118-04-09040', '118-04-09041', '118-04-09047', '118-04-09049', '118-04-09050', '118-04-09053', '118-04-09056', '118-04-09057', '118-04-09058', '118-04-09061', '118-04-09067', '118-04-09070', '118-04-09072', '118-04-09073', '118-04-09076', '118-04-09077', '118-04-09080', '118-04-09081', '118-04-09087', '118-04-09089', '118-04-09093', '118-04-09094', '118-04-09095', '118-04-09096', '118-04-09099', '118-04-09106', '118-04-09109', '118-04-09113', '118-04-09114', '118-04-09115', '118-04-09117', '118-04-09119', '118-04-09120', '118-04-09121', '118-04-09123', '118-04-09127', '118-04-09131', '118-04-09133', '118-04-09137', '118-04-09138', '118-04-09146', '118-04-09147', '118-04-09148', '118-04-09150', '118-04-09151', '118-04-09152', '118-04-09153', '118-04-09154', '118-04-09155', '118-04-09156', '118-08-00806', '118-08-09011', '118-08-09023', '118-08-09035', '118-08-09036', '118-08-09042', '118-08-09044', '118-08-09048', '118-08-09052', '118-08-09053', '118-08-09058', '118-08-09059', '118-08-09060', '118-08-09061', '118-08-09062', '118-08-09064', '118-08-09065', '118-08-09066', '118-08-92544', '118-18-00809', '118-18-00810', '118-18-00811', '118-18-09010', '118-18-09026', '120-07-09013', '120-07-09014', '120-07-09015', '120-07-09016', '120-07-09017', '120-07-09018', '120-07-09042', '123-06-00806', '123-06-00814', '123-06-09008', '123-06-09032', '123-06-09038', '123-06-09039', '123-06-09040', '123-06-09041', '123-06-09053', '123-06-09065', '123-07-00812', '123-07-00818', '123-07-00827', '123-07-09034', '123-07-09035', '123-07-09062', '123-07-09063', '123-07-09066', '123-07-09068', '123-07-09071', '123-07-09077', '123-07-09081', '123-07-09085', '123-07-09089', '123-09-09004', '123-09-09008', '123-09-09095', '123-09-09106', '126-10-00808', '126-10-09025', '126-10-09026', '126-10-09032', '126-10-09037', '126-10-09038', '126-10-09060', '126-10-09061', '134-09-00804', '134-09-00806', '134-09-00807', '134-09-00808', '134-09-09005', '134-09-09006', '134-09-09011', '134-09-09013', '134-09-09016', '134-09-09026', '134-09-09031', '134-09-09032', '134-09-09034', '134-09-09060', '134-10-00805', '134-10-09008', '134-10-09012', '134-10-09014', '134-10-09020', 
'134-10-09022', '134-10-09039', 'G.I.1869', 'G.I.2170', 'G.I.2176', 'G.I.2179', 'G.I.2180', 'G.I.2181', 'G.I.2182', 'G.I.2183', 'G.I.2184', 'G.I.2202', 'HAVR', 'HVID', 'HVIG', 'K-73-09027', 'K-73-09042', 'K-73-09044', 'K-73-09094', 'K-73-09115', 'K-73-09137', 'K-73-09144', 'KTS0', 'KTS5', 'KTS6', 'KTS7', 'LVIG', 'NEES', 'NGAB', 'SVIG', 'THOR')
Analyserer net
Fastholder 1 og beregner nye koter for 186 punkter
FEJL: Beregning ikke gennemført. Kontroller om nettet er sammenhængende, og ved flere net om der mangler fastholdte punkter.
```

Synderen er følgende linje
https://github.com/Kortforsyningen/FIRE/blob/89ad55aa4e6319d1cda00875ac519671e42f6879/fire/cli/niv/_netoversigt.py#L67
da `notnull()` ikke håndterer korrekt tommer celle korrekt (efter min mening, anyway). Det løses med f16250a der resulterer i at kun det ene punkt der er markeret fastholdt rent faktisk fastholdes:

```
>fire niv regn 2018_KDI_RIKO
Så regner vi
Fastholdte punkter:
('118-02-09003',)
Analyserer net
Fastholder 1 og beregner nye koter for 132 punkter
Skriver: {'Kontrolberegning', 'Netgeometri', 'Singulære'}
Til filen '2018_KDI_RIKO.xlsx'
Overskriver fanebladene {'Netgeometri', 'Singulære'}
    med opdaterede versioner.
Foregående versioner beholdes i 'ex'-filen '2018_KDI_RIKO-ex.xlsx'
Færdig! - åbner regneark og resultatrapport for check.
```

Så langt så godt. Fastholder vi et punkt i hvert subnet går alt også godt. Punkter `'118-02-09003', '120-07-09014', '126-10-09032', 'G.I.1869', 'G.I.2202'` fastholdes her:

```
>fire niv regn 2018_KDI_RIKO
Så regner vi
Fastholdte punkter:
('118-02-09003', '120-07-09014', '126-10-09032', 'G.I.1869', 'G.I.2202')
Analyserer net
Fastholder 5 og beregner nye koter for 182 punkter
Skriver: {'Singulære', 'Endelig beregning', 'Netgeometri'}
Til filen '2018_KDI_RIKO.xlsx'
Overskriver fanebladene {'Singulære', 'Netgeometri'}
    med opdaterede versioner.
Foregående versioner beholdes i 'ex'-filen '2018_KDI_RIKO-ex.xlsx'
Færdig! - åbner regneark og resultatrapport for check.
```

Den tilsvarende endelige beregning går også fint. Det kræver dog at man selv laver detektivarbejde og finder punkter der skal fastholdes i hvert subnet. Gør man ikke det får man et knap så kønt resultat, se udsnit af html-rapport her:

![image](https://user-images.githubusercontent.com/13132571/109830966-4a85d200-7c3f-11eb-8c62-3d13bf8413dc.png)

I og for sig forståeligt nok at det sker, men nok sjældent ønskeligt. 

I 7b8d0b1 sørges for at en advarsel om manglende fastholdte punkter skrives på skærmen. Der foreslås et punkt fra hvert subnet:

```
>fire niv regn 2018_KDI_RIKO
Så regner vi
Analyserer net
ADVARSEL: Manglende fastholdt punkt i mindst et subnet! Forslag til fastholdte punkter i hvert subnet:
  Subnet 0: 118-02-09003
  Subnet 1: 120-07-09013
  Subnet 2: 123-06-00806
  Subnet 3: 123-07-00812
  Subnet 4: 126-10-00808
Fastholder 1 og beregner nye koter for 132 punkter
Skriver: {'Netgeometri', 'Kontrolberegning', 'Singulære'}
Til filen '2018_KDI_RIKO.xlsx'
Overskriver fanebladene {'Netgeometri', 'Singulære'}
    med opdaterede versioner.
Foregående versioner beholdes i 'ex'-filen '2018_KDI_RIKO-ex.xlsx'
Færdig! - åbner regneark og resultatrapport for check.
```
Beregningen fortsættes med de fastholdte punkter brugeren har givet i regnearket. Herefter kan man selv fastholde de foreslåede i den endelige beregning. Det har dog den ulempe at der skal fjernes temmelig mange x'er i kontrolberegnings punktliste, da alle punkter der betragtes som singulære fastholdes. Så måske er det bedre at fejle hårdt når det konstateres at nogle subnet mangler fastholdte punkter? Eller måske automatisk indsætte de foreslåede fastholdte der hvor de mangler?