### PR TITLE
fire niv læs-obs: Undgå læsning af obs til tabtgået punkt

### DIFF
--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -215,6 +215,13 @@ class Punkt(FikspunktregisterObjekt):
             else:
                 return None
 
+    @property
+    def tabtgået(self) -> bool:
+        for punktinfo in self.punktinformationer:
+            if punktinfo.infotype.name == "ATTR:tabtgået":
+                return True
+        return False
+
 
 class PunktInformation(FikspunktregisterObjekt):
     __tablename__ = "punktinfo"

--- a/fire/cli/niv/_læs_observationer.py
+++ b/fire/cli/niv/_læs_observationer.py
@@ -95,8 +95,16 @@ def importer_observationer(projektnavn: str) -> pd.DataFrame:
     for punktnavn in observerede_punkter:
         try:
             punkt = fire.cli.firedb.hent_punkt(punktnavn)
-            ident = punkt.ident
-            fire.cli.print(f"Fandt {ident}", fg="green")
+            if punkt.tabtgået:
+                ident = "TABTGÅET"
+                fire.cli.print(
+                    f"{punkt.ident} er tabtgået, observationer til punktet ignoreres",
+                    fg="black",
+                    bg="yellow",
+                )
+            else:
+                ident = punkt.ident
+                fire.cli.print(f"Fandt {ident}", fg="green")
         except NoResultFound:
             fire.cli.print(f"Ukendt punkt: '{punktnavn}'", fg="red", bg="white")
             sys.exit(1)
@@ -107,7 +115,11 @@ def importer_observationer(projektnavn: str) -> pd.DataFrame:
 
     observationer["Fra"] = fra
     observationer["Til"] = til
-    return observationer
+
+    idx_tabtgået = (observationer["Fra"] == "TABTGÅET") | (
+        observationer["Til"] == "TABTGÅET"
+    )
+    return observationer[~idx_tabtgået].reset_index(drop=True)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Observationer til tabte punkter indlæses ikke. Ved læsning af observationer til tabt punkt gives advarsel som set herunder:

![image](https://user-images.githubusercontent.com/13132571/110023944-0c1b1080-7d2e-11eb-9eab-f4b21c52e29e.png)

Hvis observationen skulle have været til et andet punkt er det nødvendigt at rette punktnummeret i observationsfilen.