### PR TITLE
Sagsmateriale

### DIFF
--- a/fire/api/model/__init__.py
+++ b/fire/api/model/__init__.py
@@ -124,7 +124,6 @@ class Konfiguration(DeclarativeBase):
     __tablename__ = "konfiguration"
     objektid = Column(Integer, primary_key=True)
     dir_skitser = Column(String, nullable=False)
-    dir_materiale = Column(String, nullable=False)
 
 
 # Expose these types

--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -1,5 +1,5 @@
 import enum
-from sqlalchemy import Column, String, Integer, ForeignKey
+from sqlalchemy import Column, String, Integer, ForeignKey, LargeBinary
 from sqlalchemy.orm import relationship
 
 import fire
@@ -174,8 +174,7 @@ class SagseventInfo(RegisteringTidObjekt):
 class SagseventInfoMateriale(DeclarativeBase):
     __tablename__ = "sagseventinfo_materiale"
     objektid = Column(Integer, primary_key=True)
-    md5sum = Column(String(32), nullable=False)
-    sti = Column(String(4000), nullable=False)
+    materiale = Column(LargeBinary, nullable=False)
     sagseventinfoobjektid = Column(
         Integer, ForeignKey("sagseventinfo.objektid"), nullable=False
     )

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -117,8 +117,7 @@ CREATE TABLE konfiguration (
     START WITH
       1 INCREMENT BY 1 ORDER NOCACHE
   ) PRIMARY KEY,
-  dir_skitser VARCHAR(200) NOT NULL,
-  dir_materiale VARCHAR(200) NOT NULL
+  dir_skitser VARCHAR(200) NOT NULL
 );
 
 
@@ -273,8 +272,7 @@ CREATE TABLE SAGSEVENTINFO_MATERIALE (
     START WITH
       1 INCREMENT BY 1 ORDER NOCACHE
   ) PRIMARY KEY,
-  md5sum VARCHAR2(32) NOT NULL,
-  sti VARCHAR2(4000) NOT NULL,
+  materiale BLOB NOT NULL,
   sagseventinfoobjektid INTEGER NOT NULL
 );
 
@@ -757,8 +755,7 @@ COMMENT ON COLUMN Sagseventinfo.sagseventid IS 'Den sagsevent som sagseventinfo 
 COMMENT ON COLUMN sagseventinfo_html.html IS 'Generisk operatørlæsbart orienterende rapportmateriale.';
 
 COMMENT ON TABLE sagseventinfo_materiale IS 'Eksternt placeret materiale knyttet til en event';
-COMMENT ON COLUMN sagseventinfo_materiale.md5sum IS 'Sum brugt til at kontrollere materialets integritet.';
-COMMENT ON COLUMN sagseventinfo_materiale.sti IS 'Placering af materialet.';
+COMMENT ON COLUMN sagseventinfo_materiale.materiale IS 'Zippet samling af observationsfiler og andet relevante materiale.';
 
 COMMENT ON TABLE sagsinfo IS 'Samling af administrativt relaterede sagshændelser.';
 COMMENT ON COLUMN sagsinfo.aktiv IS 'Markerer om sagen er åben eller lukket.';

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -34,11 +34,9 @@
 -------------------------------------------------------------------------------
 -- Grundlæggende FIRE konfiguration
 INSERT INTO konfiguration (
-    dir_skitser,
-    dir_materiale
+    dir_skitser
 ) VALUES (
-    'F:\GDB\FIRE\skitser',
-    'F:\GDB\FIRE\materiale'
+    'F:\GDB\FIRE\skitser'
 )
 
 -- SELECT
@@ -1260,12 +1258,10 @@ INSERT INTO sagseventinfo (
 );
 
 INSERT INTO sagseventinfo_materiale (
-    sti,
-    md5sum,
+    materiale,
     sagseventinfoobjektid
 ) VALUES (
-    'materiale/K-63-09446.pdf',
-    'af8f278306a057ba41bef6c29911df79',
+    TO_BLOB('f1cba4f8bc04d5c4809b1daccb63bd7b'),
     (SELECT objektid
      FROM sagseventinfo
      WHERE sagseventid='sagevent-aaaa-bbbb-0005-000000000005'

--- a/test/test_firedb.py
+++ b/test/test_firedb.py
@@ -6,5 +6,4 @@ def test_has_session(firedb: FireDb):
 
 
 def test_konfiguration(firedb: FireDb):
-    assert firedb.basedir_materiale == r"F:\GDB\FIRE\materiale"
     assert firedb.basedir_skitser == r"F:\GDB\FIRE\skitser"

--- a/test/test_ident.py
+++ b/test/test_ident.py
@@ -75,10 +75,19 @@ def test_integration_tilknyt_landsnumre(firedb):
         FikspunktsType.HØJDE,
     ]
 
+    # Hvis test-suiten køres flere gange uden at databasen nulstilles kan vi
+    # ikke regne med stabilt landsnummer output i denne test.  Vi sjusser os frem
+    # til det rigtige svar på baggrund af databasens nuværende indhold
+    n = (
+        firedb.session.query(PunktInformation)
+        .filter(PunktInformation.tekst.startswith("K-63-0900"))
+        .count()
+    )
+
     punkter = firedb.hent_punkt_liste(punkt_ider)
     landsnumre = firedb.tilknyt_landsnumre(punkter, fikspunktstyper)
 
-    for i, landsnummer in enumerate(landsnumre, 1):
+    for i, landsnummer in enumerate(landsnumre, n + 1):
         assert landsnummer.tekst == f"K-63-0900{i}"
 
 

--- a/test/test_observation.py
+++ b/test/test_observation.py
@@ -61,7 +61,7 @@ def test_hent_observationer_naer_opstillingspunkt(firedb: FireDb):
 def test_hent_observationer_naer_geometri(firedb: FireDb):
     go = firedb.hent_geometri_objekt(punktid="67e3987a-dc6b-49ee-8857-417ef35777af")
     os = firedb.hent_observationer_naer_geometri(go.geometri, 10000)
-    assert len(os) == 68
+    assert len(os) >= 68  # der KAN komme flere obs ved gentagende kørsler af tests
     point = Geometry("POINT (10.2112609352788 56.1567354902778)")
     os = firedb.hent_observationer_naer_geometri(point, 100)
     assert len(os) == 6
@@ -75,7 +75,7 @@ def test_hent_observationer_naer_geometri(firedb: FireDb):
         )
     )
     os = firedb.hent_observationer_naer_geometri(polygon, 100)
-    assert len(os) == 10
+    assert len(os) >= 10  # der KAN komme flere obs ved gentagende kørsler af tests
 
 
 def test_indset_observation(firedb: FireDb, sag: Sag, punkt: Punkt):

--- a/test/test_sag.py
+++ b/test/test_sag.py
@@ -1,7 +1,16 @@
+import os
+
 import pytest
 
 from fire.api import FireDb
-from fire.api.model import Sag, Sagsinfo, Sagsevent, SagseventInfo, EventType
+from fire.api.model import (
+    Sag,
+    Sagsinfo,
+    Sagsevent,
+    SagseventInfo,
+    SagseventInfoMateriale,
+    EventType,
+)
 
 
 def test_hent_sag(firedb: FireDb, sag: Sag):
@@ -18,6 +27,40 @@ def test_indset_sag(firedb: FireDb):
     sagsinfo = Sagsinfo(aktiv="true", behandler="test")
     sag = Sag(sagsinfos=[sagsinfo])
     firedb.indset_sag(sag)
+
+
+def test_indset_sagsevent(firedb: FireDb, sag: Sag):
+    sagseventinfo = SagseventInfo(beskrivelse="Testing testing")
+    firedb.indset_sagsevent(
+        Sagsevent(
+            sag=sag,
+            eventtype=EventType.KOMMENTAR,
+            sagseventinfos=[sagseventinfo],
+        )
+    )
+
+    s = firedb.hent_sag(sag.id)
+    assert s.sagsevents[0].sagseventinfos[0].beskrivelse == "Testing testing"
+
+
+def test_indset_sagsevent_materiale(firedb: FireDb, sag: Sag):
+
+    blob = os.urandom(1000)
+
+    sagseventinfo = SagseventInfo(
+        beskrivelse="Testing testing",
+        materialer=[SagseventInfoMateriale(materiale=blob)],
+    )
+    firedb.indset_sagsevent(
+        Sagsevent(
+            sag=sag,
+            eventtype=EventType.KOMMENTAR,
+            sagseventinfos=[sagseventinfo],
+        )
+    )
+
+    s = firedb.hent_sag(sag.id)
+    assert s.sagsevents[0].sagseventinfos[0].materialer[0].materiale == blob
 
 
 def test_indset_sagsevent(firedb: FireDb, sag: Sag):


### PR DESCRIPTION
Ændrer DDL så sagsmateriale gemmes som BLOB fremfor en sti til et netværksdrev. `fire niv luk-sag` gemmer nu sagsmateriale i databasen.

Testdatabasen opdateres umiddelbart efter dette PR er merged. Venter nok lige en dags tid med at gøre det samme på produktionsdatabasen selvom det i dette tilfælde skulle være ganske ufarligt (den ændrede tabel bruges ikke i UM-mapping). 