### PR TITLE
Undgå fejl ved indsættelse af afmærkning

### DIFF
--- a/fire/cli/niv/_ilæg_nye_punkter.py
+++ b/fire/cli/niv/_ilæg_nye_punkter.py
@@ -180,7 +180,15 @@ def ilæg_nye_punkter(projektnavn: str, sagsbehandler: str, **kwargs) -> None:
                 bg="white",
                 bold=True,
             )
-        punktinfo.append(PunktInformation(infotype=afmærkning_pit, punkt=punkt))
+
+        # Grundet den lidt kluntede løsning med AFM:nnnn punktinfo er fx AFM:2700 (bolt)
+        # registreret som en tekst-punktinformation (frem for flag, som ville være den ideelle løsning)
+        # og tekst attributten skal derfor udfyldes. Vi bruger tekstnøgle til afm_ids.
+        punktinfo.append(
+            PunktInformation(
+                infotype=afmærkning_pit, punkt=punkt, tekst=afm.capitalize()
+            )
+        )
 
         # Tilføj punktbeskrivelsen som punktinformation, hvis anført
         if not pd.isna(nyetablerede["Beskrivelse"][i]):

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -51,11 +51,11 @@ Insert into PUNKTINFOTYPE (INFOTYPEID,INFOTYPE,ANVENDELSE,BESKRIVELSE) values (3
 Insert into PUNKTINFOTYPE (INFOTYPEID,INFOTYPE,ANVENDELSE,BESKRIVELSE) values (331,'ATTR:tabtgået','FLAG','Fysisk punkt ikke længere tilgængeligt');
 INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (360, 'ATTR:beskrivelse', 'TEKST', 'Tekstbeskrivelse af punktet');
 INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (362, 'AFM:højde_over_terræn', 'TAL', 'Fikspunkts højde over terræn');
-INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (363, 'AFM:4999', 'FLAG', 'Ukendt fikspunktstype');
-INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (364, 'AFM:2700', 'FLAG', 'Bolt');
-INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (365, 'AFM:2701', 'FLAG', 'Lodret bolt');
-INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (366, 'AFM:2950', 'FLAG', 'Skruepløk');
-INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (367, 'AFM:5998', 'FLAG', 'Ingen');
+INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (363, 'AFM:4999', 'TEKST', 'Ukendt fikspunktstype');
+INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (364, 'AFM:2700', 'TEKST', 'Bolt');
+INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (365, 'AFM:2701', 'TEKST', 'Lodret bolt');
+INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (366, 'AFM:2950', 'TEKST', 'Skruepløk');
+INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (367, 'AFM:5998', 'TEKST', 'Ingen');
 INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (370, 'ATTR:muligt_datumstabil', 'FLAG', 'Markering af om punkt potentielt er datumstabilt');
 INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES (371, 'REGION:DK', 'FLAG', 'Punkter i Danmark');
 


### PR DESCRIPTION
I fire niv ilæg-nye-punkter fejlede koden ved indsættelse af
afmærkningspunktinfo, da afmærkningner af typen AFM:xxxx kræver at
tekstfeltet er udfyldt. Dette tages hånd om ved at bruge teksten fra
afmærkningscellen i regnearket.

Fejlen opstår da insert trigger på tabellen kontrollerer at det indsatte
er i overenstemmelse med den indsatte infotype. Under test er denne fejl
ikke opstået da triggeren PUNKTINFO_BIU_TRG fejlagtigt har været slået fra.