### PR TITLE
Sorter punkter efter landsnummer i revisionsudtræk

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -79,9 +79,9 @@ def udtræk_revision(
     stmt = text(pkt_i_distrikter).columns(Punkt.objektid)
     punkter = fire.cli.firedb.session.query(Punkt).from_statement(stmt).all()
 
-    for punkt in punkter:
+    for punkt in sorted(punkter):
         datumstabilt = False
-        ident = punkt.ident
+        ident = punkt.landsnummer
         fire.cli.print(f"Punkt: {ident}")
 
         # Angiv ident og lokationskoordinat


### PR DESCRIPTION
Punkt tilføjes landsnummer-property og implementerer nu __lt__ og __eq__
med henblik på at kunne sortere en liste af punkter. Punkterne sorteres
leksikografisk på deres landsnumre. Denne sortering sikrer en geografisk
gruppering af punkterne, også selvom punkternes har GI- eller GNSS-
identer.

Closes #368