### PR TITLE
Doc: Reparer installationsvejledning+konfigurationsfil

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@ FIRE - FIkspunktREgister
     :maxdepth: 2
     :caption: Contents:
 
+    konfiguration
     installation
     datamodel
     for_udviklere

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,7 +145,15 @@ Efter endt installation gør da som ``conda`` siger og aktiver dit nye "fire env
   Bemærk at ``(base)`` nu er ændret til ``(fire)`` i kommandolineprompten.
   Det betyder at dit fire-miljø nu er aktivt.
 
-Installer FIRE
+For at FIRE kan forbinde til databasen er det nødvendigt at tilføje en
+:ref:`konfigurationsfil <konfigurationsfil>` til systemet hvori adgangsinformation
+til databasen er registreret. Placer den i mappen ``C:\Users\<brugernavn>``.
+
+.. note::
+
+  Tag fat i en kollega for at få oplyst brugernavn, adgangskode osv.
+
+Med konfigurationsfilen på plads kan vi nu installere FIRE:
 
 .. code-block::
 
@@ -161,12 +169,13 @@ Installer FIRE
     Successfully installed click-plugins-1.1.1 fire-1.1.0
 
 
-Konfigurationsfil
-.................
+Bekræft at installation er gennemført korrekt
 
-For at FIRE kan forbinde til databasen er det nødvendigt at tilføje en
-:ref:`konfigurationsfil <konfiguration>` til systemet hvori adgangsinformation til databasen er
-registreret.
+    .. code-block::
+
+        (fire) C:\FIRE>fire --version
+        fire, version 1.1.0
+
 
 
 Flame - QGIS plugin

--- a/docs/konfiguration.rst
+++ b/docs/konfiguration.rst
@@ -1,3 +1,5 @@
+.. _konfigurationsfil:
+
 Konfigurationsfil
 =================
 
@@ -29,11 +31,6 @@ måde:
     schema = <schema>
 
 
-
-.. note::
-
-    Tag fat i en kollega for at få oplyst brugernavn, adgangskode osv.
-
 Under Windows placeres konfigurationsfilen i en af følgende stier::
 
     C:\Users\<brugernavn>\fire.ini
@@ -44,10 +41,3 @@ og på et UNIX-baseret system placeres filen et af følgende steder::
     home/<brugernavn>/fire.ini
     home/<brugernavn>/.fire.ini
     /etc/fire.ini
-
-Bekræft at installation er gennemført korrekt
-
-.. code-block::
-
-    (fire) C:\FIRE>fire --version
-    fire, version 1.1.0


### PR DESCRIPTION
Efter afsnittet om konfigurationsfilen blev udskilt til egen fil
forsvandt den fra indholdsfortegnelsen pga manglende henvisning i
index.rst. Dette samt manglende labels er fikset. Derudover er
læseflowet optimeret så man kan nøjes med at læse
installationsvejledningen.

CC @larsnaesbye 