### PR TITLE
Udelad uaktuelle identer fra punkt._identer

### DIFF
--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -164,6 +164,7 @@ class Punkt(FikspunktregisterObjekt):
         """
         if not self._identer:
             temp = []
+            
             for punktinfo in self.punktinformationer:
                 if punktinfo.registreringtil:
                     continue

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -165,6 +165,8 @@ class Punkt(FikspunktregisterObjekt):
         if not self._identer:
             temp = []
             for punktinfo in self.punktinformationer:
+                if punktinfo.registreringtil:
+                    continue
                 if punktinfo.infotype.name.startswith("IDENT:") and punktinfo.tekst:
                     temp.append(Ident(punktinfo))
 

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -164,7 +164,6 @@ class Punkt(FikspunktregisterObjekt):
         """
         if not self._identer:
             temp = []
-            
             for punktinfo in self.punktinformationer:
                 if punktinfo.registreringtil:
                     continue


### PR DESCRIPTION
`punkt._identer` udtrækkes fra punktets tilhørende punktinformationer, men udelader
punktinformationens `registreringtil`-information, så `punkt.ident` returnerer den
højest rangerende ident uden skelen til om den er aktuel eller ej.

Da `@property ident` er beregnet til identifikation af punktet i en primært
menneskelæsbar sammenhæng er det nok mest fornuftigt at udelade uaktuelle
identer. I tilfælde hvor "uaktuelle er aktuelle" vil vi formodentlig alligevel iterere
over alle punktinfø og dermed have adgang til `registreringfra/til`.