### PR TITLE
Tilføj black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    -   id: black
+

--- a/docs/for_udviklere.rst
+++ b/docs/for_udviklere.rst
@@ -20,7 +20,7 @@ Start med at clone git repositoriet::
 
     > git clone https://github.com/Kortforsyningen/FIRE.git
 
-Et godt udviklingsmiljø at tage udgangspunkt i er `fire-dev.yaml`, som nemt
+Et godt udviklingsmiljø at tage udgangspunkt i er `environment-dev.yaml`, som nemt
 installeres med Conda. Fra fire git-repositoriet køres::
 
     > conda env create --file environment-dev.yml
@@ -31,6 +31,21 @@ Herefter burde alle de essentielle programmer og biblioteker være til rådighed
 Installer en udviklingsversion af fire med::
 
     > pip install -e .
+
+og installer git hooks::
+
+    > pre-commit install
+
+
+.. note::
+
+    ``pre-commit`` bruges til at afvikle forskellige "hooks"  inden et git commit.
+    ``pre-commit`` *kan* blive forvirret over SIT's noget aparte valg af ``%HOME%``
+    på ``H:\`` hvorfor det anbefales at sætte ``%PRE_COMMIT_HOME%`` som en global
+    miljøvariabel der peger på ``C:\Users\bxxxxx\.cache\pre-commit``. Søg efter
+    "Rediger miljøvariabler for din konto" i startmenuen.
+
+
 
 Test-suiten køres med::
 
@@ -66,17 +81,11 @@ Kodestil
 skrives ligeledes på dansk. Det er tilladt at skrive kommentarer, funktions- og
 variabelnavne på engelsk. git commits bør så vidt muligt skrives på dansk.
 
-Al kode i fire repositoriet skal køres gennem ``black`` inden det committes.
-Dette gøres for at skabe et ensartet udtryk på tværs af hele kodebasen. Desuden
-har black den bivirking at forstyrrende, overflødige ændringer typisk forsvinder
-fra diffs mellem to commits, hvilket gør det væsentligt nemmere at lave review
-af kodeændringer.
-
-Kør ``black`` med::
-
-    > black .
-
-Hvis ikke ``black`` er kørt inden kode pushes til GitHub vil CI tests fejle.
+Al kode i fire repositoriet skal køres automatisk gennem ``black`` via et git
+pre-commit hook inden det committes. Dette gøres for at skabe et ensartet udtryk
+på tværs af hele kodebasen. Desuden har black den bivirking at forstyrrende,
+overflødige ændringer typisk forsvinder fra diffs mellem to commits, hvilket gør
+det væsentligt nemmere at lave review af kodeændringer.
 
 
 Dokumentation

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - openpyxl=3.0.*
   - pandas=1.2.*
   - pip=21.0.*
+  - pre-commit=2.15.*
   - pylint=2.6.*
   - pyproj=2.6.*
   - pytest=6.2.*


### PR DESCRIPTION
Afvikler `black` i forbindelse med git commits:
```
(fire-dev) C:\dev\fire>git commit -m dummy
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted fire\api\firedb.py
All done! \u2728 \U0001f370 \u2728
1 file reformatted.
```

Bemærk at der kan opstå fejl pga SIT's besynderlige valg af `%HOME%` på `H:\`:

```
(fire-dev) C:\dev\fire>git commit -m dummy
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to H:\patch1632218406-17172.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Restored changes from H:\patch1632218406-17172.
An unexpected error has occurred: CalledProcessError: command: ('C:\\Users\\b012349\\AppData\\Local\\Continuum\\miniconda3\\envs\\fire-dev\\python.exe', '-mvirtualenv', 'H:\\repob8nvmsty\\py_env-python3')
return code: 1
expected return code: 0
stdout:
    PermissionError: [WinError 5] Adgang nægtet: 'H:\\repob8nvmsty'

stderr: (none)
Check the log at H:\pre-commit.log

(fire-dev) C:\dev\fire>
```

Fikses ved at sætte `%PRE_COMMIT_HOME%` til noget lokalt, fx `C:\Users\bxxxx\.cache\pre-commit`. Søg efter "Rediger miljøvariable for din konto" og tilføj miljøvariablen. Det skulle løses problemet med at skrive til H:\

Efter merge af dette PR er det som udvikler naturligvis nødvendigt at lave en `conda install pre-commit -c conda-forge`.

Closes https://github.com/Kortforsyningen/FIRE/issues/142