### PR TITLE
Medtag naturlige fikspunkter i revisionsudtræk

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -45,7 +45,6 @@ def udtræk_revision(projektnavn: str, kriterier: Tuple[str], **kwargs) -> None:
         "ATTR:hjælpepunkt",
         "ATTR:tabtgået",
         "ATTR:teknikpunkt",
-        "AFM:naturlig",
         "ATTR:MV_punkt",
     ]
 


### PR DESCRIPTION
Naturlige fikspunkter bliver udstillet på Valdemar og bør derfor
tages i betragtning i forbindelse med punktrevision.

Closes #434