### PR TITLE
 tilknyt_landsnumre(): sikr at input- og outputlister matcher 

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -45,7 +45,6 @@ def udtræk_revision(projektnavn: str, kriterier: Tuple[str], **kwargs) -> None:
         "ATTR:hjælpepunkt",
         "ATTR:tabtgået",
         "ATTR:teknikpunkt",
-        "AFM:naturlig",
         "ATTR:MV_punkt",
     ]
 


### PR DESCRIPTION
Indfør garanti for at outputlisten matcher inputlisterne. Før dette
commit var der risiko for at outputlisten blev genereret i en
anden rækkefølge end inputlisterne, hvilket resulterede i fejl
når de to blev matched op mod hinanden, fx i `fire niv ilæg-nye-punkter`.