### PR TITLE
bug: Søg kun blandt gyldige identer med FireDb.hent_punkter

### DIFF
--- a/fire/api/hent.py
+++ b/fire/api/hent.py
@@ -94,6 +94,7 @@ class FireDbHent(BaseFireDb):
                 .join(PunktInformationType)
                 .filter(
                     PunktInformationType.name.startswith("IDENT:"),
+                    PunktInformation._registreringtil == None,  # NOQA
                     or_(
                         PunktInformation.tekst == ident,
                         PunktInformation.tekst == f"FO  {ident}",


### PR DESCRIPTION
Grundet fejl er der enkelte eksempler på duplikerede landsnumre
i databasen. Dog er kun det ene aktuelt (registrerintil=null) men
begge fremsøges med hent_punkter() før denne ændring.

Med dette commit sikres det at der kun søges blandt de identer der
aktuelt er i brug, og ikke afregistrerede identer.

Før denne ændring:

```
(fire-dev) c:\dev\fire>fire info punkt --db=prod K-66-09058

--------------------------------------------------------------------------------
 PUNKT K-66-09058 (1/2)
--------------------------------------------------------------------------------
  Lokation                    POINT (9.91406982142058 56.0426040534891)
  Oprettelsesdato             1976-05-24 01:00:00
  AFM:2713                    Lodret bolt, DSB.
  AFM:vertikal
  AFM:højde_over_terræn       0.2
 -ATTR:beskrivelse
                              Banelinien Skanderborg - Vejle, N. side.
                              Ved 85.1 banekm.
                              Underføring af Vej 445, Ryvej.
                              Punkt i dæksten.
                              0.07 m fra Ø. kant.
                              0.07 m fra N. kant.
                              0.23 m fra S. kant.
  ATTR:beskrivelse            Banelinien Skanderborg-Vejle, N. side.
                              Ved 85.1 banekm.
                              Underføring af Ryvej.
                              Punkt i overkant af dæksten.
                              0.07 m fra Ø. ende.
                              0.07 m fra N. kant.

                              Punkt vedligeholdes ikke.
  ATTR:højdefikspunkt
 -ATTR:bemærkning             Punkt oprettet
  ATTR:bemærkning             Rev. uge 16 2009. U.K.
  REGION:DK
  IDENT:refgeo_id             49949
  IDENT:landsnr               K-66-09058

--- KOORDINATER ---
* 2002-03-04 13:00  EPSG:5799       t 43.31700 (999)
* 1976-07-01 01:00  DK:GM91         n 43.38000 (10)


--------------------------------------------------------------------------------
 PUNKT K-66-09061 (2/2)
--------------------------------------------------------------------------------
  Lokation                    POINT (9.930711 56.036334)
  Oprettelsesdato             2021-10-19 19:59:14.584655
  AFM:højde_over_terræn       0.2
  AFM:2700                    Bolt
  ATTR:beskrivelse            Adelgade 105.
                              Skanderborg By.
                              Beboelsesejendom.
                              Punkt i Ø. facade.
                              0.21 m fra N. hjørne. (stumpt hjørne).
                              1.45 m under sokkelkant.
  REGION:DK
  ATTR:højdefikspunkt
 -IDENT:landsnr               k-66-09002
 -IDENT:landsnr               K-66-09058
  IDENT:landsnr               K-66-09061

--- KOORDINATER ---
```

og efter:

```
--------------------------------------------------------------------------------
 PUNKT K-66-09058
--------------------------------------------------------------------------------
  Lokation                    POINT (9.91406982142058 56.0426040534891)
  Oprettelsesdato             1976-05-24 01:00:00
  AFM:2713                    Lodret bolt, DSB.
  AFM:vertikal
  AFM:højde_over_terræn       0.2
 -ATTR:beskrivelse
                              Banelinien Skanderborg - Vejle, N. side.
                              Ved 85.1 banekm.
                              Underføring af Vej 445, Ryvej.
                              Punkt i dæksten.
                              0.07 m fra Ø. kant.
                              0.07 m fra N. kant.
                              0.23 m fra S. kant.
  ATTR:beskrivelse            Banelinien Skanderborg-Vejle, N. side.
                              Ved 85.1 banekm.
                              Underføring af Ryvej.
                              Punkt i overkant af dæksten.
                              0.07 m fra Ø. ende.
                              0.07 m fra N. kant.

                              Punkt vedligeholdes ikke.
  ATTR:højdefikspunkt
 -ATTR:bemærkning             Punkt oprettet
  ATTR:bemærkning             Rev. uge 16 2009. U.K.
  REGION:DK
  IDENT:refgeo_id             49949
  IDENT:landsnr               K-66-09058

--- KOORDINATER ---
* 2002-03-04 13:00  EPSG:5799       t 43.31700 (999)
* 1976-07-01 01:00  DK:GM91         n 43.38000 (10)
```