### PR TITLE
Ret fejl i revisionsarklandsnummerangivelsen

### DIFF
--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -232,7 +232,10 @@ class Punkt(FikspunktregisterObjekt):
     def landsnummer(self) -> str:
         landsnumre = []
         for punktinfo in self.punktinformationer:
-            if punktinfo.infotype.name == "IDENT:landsnr":
+            if (
+                punktinfo.infotype.name == "IDENT:landsnr"
+                and not punktinfo.registreringtil
+            ):
                 landsnumre.append(punktinfo.tekst)
 
         if landsnumre:


### PR DESCRIPTION
Identifikationssøjlen "Punkt" i revisionsregnearket får fejlagtigt
tildelt værdien for første forekommende landsnummerregistrering,
uagtet om den er slukket eller ej.

Rettet ved at checke "registreringtil" på property landsnummer.

Fixes #486 