### PR TITLE
feat: separate geojson-filer for kontrol og endelig beregning

### DIFF
--- a/docs/workshop/workshop.rst
+++ b/docs/workshop/workshop.rst
@@ -593,11 +593,14 @@ til fastholdelse i hvert subnet.
 Udover beregningsresultatet i projektregnearket genereres
 flere resultatfiler, bl.a.
 
-- en *projektnavn*-resultat.xml (til intern brug for ``fire``)
-- en *projektnavn*-resultat.html
+- *projektnavn*-resultat.xml (til intern brug for ``fire``)
+- *projektnavn*-resultat.html
+- *projektnavn*-kon-observationer.geojson
+- *projektnavn*-kon-punkter.geojson
 
 I .html-filen findes diverse statistik over udjævningsberegningen, som det underliggende
-kode (GNU Gama) genererer. Filen åbnes også default efter kørslen.
+kode (GNU Gama) genererer. Filen åbnes også default efter kørslen. De to geojson-filer
+kan bruges til at visualisere beregningen i fx QGIS.
 
 I resultatfilen er der nu tre nye faner;
 
@@ -632,6 +635,13 @@ beregning. Derefter køres ``fire niv regn`` igen.
 Denne gang vil resultatfanebladet hedde *Endelig beregning*. Er man ikke tilfreds med den
 kan man slette (eller omdøbe) fanebladet, tilpasse sine fastholdte punkter i fanebladet
 *Kontrolberegning*, og køre beregningen en gang til.
+
+Efter den endelige beregning opdateres de to geojson-filer der blev genereret med
+`fire niv læs-observationer`, så beregningsresultatet også fremgår af disse. Det
+drejer sig om filerne:
+
+- *projektnavn*-observationer.geojson
+- *projektnavn*-punkter.geojson
 
 
 Trin 7) ilæg-observationer

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -465,6 +465,7 @@ def obs_feature(
                 "Opstillinger": int(observationer.at[i, "Opst"]),
                 "Journal": observationer.at[i, "Journal"],
                 "Type": observationer.at[i, "Type"],
+                "Slukket": observationer.at[i, "Sluk"],
             },
             "geometry": {
                 "type": "LineString",

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from typing import (
     Dict,
+    Tuple,
 )
 
 import click
@@ -375,20 +376,11 @@ def find_sagsid(sagsgang: pd.DataFrame) -> str:
 
 
 # ------------------------------------------------------------------------------
-def punkter_geojson(
-    projektnavn: str,
-    punkter: pd.DataFrame,
-) -> None:
-    """Skriv punkter/koordinater i geojson-format"""
-    with open(f"{projektnavn}-punkter.geojson", "wt") as punktfil:
-        til_json = {
-            "type": "FeatureCollection",
-            "Features": list(punkt_feature(punkter)),
-        }
-        json.dump(til_json, punktfil, indent=4)
+def _geojson_filnavn(projektnavn: str, infiks: str, variant: str):
+    """Generer filnavn på geojson-fil"""
+    return f"{projektnavn}{infiks}-{variant}.geojson"
 
 
-# ------------------------------------------------------------------------------
 def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
     """Omsæt punktinformationer til JSON-egnet dict"""
     for i in range(punkter.shape[0]):
@@ -431,6 +423,97 @@ def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
             },
         }
         yield feature
+
+
+def punkter_geojson(
+    punkter: pd.DataFrame,
+) -> str:
+    """Returner punkter/koordinater som geojson-streng"""
+    # with open(f"{projektnavn}{infiks}-punkter.geojson", "wt") as punktfil:
+    til_json = {
+        "type": "FeatureCollection",
+        "Features": list(punkt_feature(punkter)),
+    }
+    return json.dumps(til_json, indent=4)
+
+
+def skriv_punkter_geojson(projektnavn: str, punkter: pd.DataFrame, infiks: str = ""):
+    """Skriv geojson-fil med punktdata til disk"""
+    geojson = punkter_geojson(punkter)
+    filnavn = _geojson_filnavn(projektnavn, infiks, "punkter")
+    with open(filnavn, "wt") as punktfil:
+        punktfil.write(geojson)
+
+
+# ------------------------------------------------------------------------------
+def obs_feature(
+    punkter: pd.DataFrame, observationer: pd.DataFrame, antal_målinger: Dict[Tuple, int]
+) -> Dict[str, str]:
+    """Omsæt observationsinformationer til JSON-egnet dict"""
+    for i in range(observationer.shape[0]):
+        fra = observationer.at[i, "Fra"]
+        til = observationer.at[i, "Til"]
+        feature = {
+            "type": "Feature",
+            "properties": {
+                "Fra": fra,
+                "Til": til,
+                "Målinger": antal_målinger[tuple(sorted([fra, til]))],
+                "Afstand": observationer.at[i, "L"],
+                "ΔH": observationer.at[i, "ΔH"],
+                # konvertering, da json.dump ikke uderstøtter int64
+                "Opstillinger": int(observationer.at[i, "Opst"]),
+                "Journal": observationer.at[i, "Journal"],
+                "Type": observationer.at[i, "Type"],
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [punkter.at[fra, "Øst"], punkter.at[fra, "Nord"]],
+                    [punkter.at[til, "Øst"], punkter.at[til, "Nord"]],
+                ],
+            },
+        }
+        yield feature
+
+
+def observationer_geojson(
+    punkter: pd.DataFrame,
+    observationer: pd.DataFrame,
+) -> None:
+    """Skriv observationer til geojson-fil"""
+
+    fra = observationer["Fra"]
+    til = observationer["Til"]
+
+    # Optæl antal frem-og/eller-tilbagemålinger pr. strækning: Vi starter
+    # med en dict med et nul for hver strækning
+    par = [tuple(p) for p in zip(fra, til)]
+    antal_målinger = dict((tuple(sorted(p)), 0) for p in par)
+    # ...og så tæller vi det relevante element op for hver observation
+    for p in par:
+        # Indeksering med tuple(sorted(p)) da set(p) ikke kan hashes
+        antal_målinger[tuple(sorted(p))] += 1
+
+    til_json = {
+        "type": "FeatureCollection",
+        "Features": list(obs_feature(punkter, observationer, antal_målinger)),
+    }
+
+    return json.dumps(til_json, indent=4)
+
+
+def skriv_observationer_geojson(
+    projektnavn: str,
+    punkter: pd.DataFrame,
+    observationer: pd.DataFrame,
+    infiks: str = "",
+) -> None:
+    """Skriv geojson-fil med observationsdata til disk"""
+    filnavn = _geojson_filnavn(projektnavn, infiks, "observationer")
+    geojson = observationer_geojson(punkter, observationer)
+    with open(filnavn, "wt") as obsfil:
+        obsfil.write(geojson)
 
 
 def bekræft(spørgsmål: str, gentag=True) -> bool:

--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -17,7 +17,8 @@ from . import (
     find_faneblad,
     gyldighedstidspunkt,
     niv,
-    punkter_geojson,
+    skriv_punkter_geojson,
+    skriv_observationer_geojson,
     skriv_ark,
     er_projekt_okay,
 )
@@ -52,9 +53,11 @@ def regn(projektnavn: str, **kwargs) -> None:
     if kontrol:
         aktuelt_faneblad = "Punktoversigt"
         næste_faneblad = "Kontrolberegning"
+        infiks = "-kon"
     else:
         aktuelt_faneblad = "Kontrolberegning"
         næste_faneblad = "Endelig beregning"
+        infiks = ""
 
     # Håndter fastholdte punkter og slukkede observationer.
     observationer = find_faneblad(projektnavn, "Observationer", arkdef.OBSERVATIONER)
@@ -85,7 +88,13 @@ def regn(projektnavn: str, **kwargs) -> None:
     resultater[næste_faneblad] = beregning
 
     # ...og beret om resultaterne
-    punkter_geojson(projektnavn, resultater[næste_faneblad])
+    skriv_punkter_geojson(projektnavn, resultater[næste_faneblad], infiks=infiks)
+    skriv_observationer_geojson(
+        projektnavn,
+        resultater[næste_faneblad].set_index("Punkt"),
+        observationer,
+        infiks=infiks,
+    )
     skriv_ark(projektnavn, resultater)
     webbrowser.open_new_tab(htmlrapportnavn)
     if "startfile" in dir(os):


### PR DESCRIPTION
Skæln mellem kontrolberegning og endelig beregning i geojson-output.

Situationen før og efter dette commit ved kørsel af udvalgte niv
kommandoer:

* `fire niv læs-observationer`:
   - før og efter: `projekt-observationer.geojson` OG `projekt-punkter.geojson` oprettes 
* `fire niv regn` (første gang):
    - før: `projekt-punkter.geojson` overskrives med information fra kontrolberegning (koter, fastholdt osv)
    - efter: `projekt-kon-punkter.geojson` oprettes med information fra kontrolberegning
* `fire niv regn` (anden gang):
    - før: `projekt-punkter.geojson` overskrives *igen* med ny information, denne gang fra endelig beregning.
    - efter: `projekt-punkter.geojson` og `projekt-observationer.geojson` overskrives *igen* med ny information, denne gang fra endelig beregning.

Derudover er tilføjet en attributten "slukket" til observationsfilerne, så det er muligt at frasortere slukkede observationer i visualiseringer.

closes #490
closes #505