### PR TITLE
bugfix: Undgå fejl ved brug af .fire.ini på Windows

### DIFF
--- a/fire/api/configuration.py
+++ b/fire/api/configuration.py
@@ -13,7 +13,7 @@ APPDATADIR = Path("C:\\Users\\Default\\AppData\\Local\\fire")
 
 RC_PATHS = (
     lambda: HOME / RC_NAME,
-    lambda: HOME / "." + RC_NAME,
+    lambda: HOME / ("." + RC_NAME),
     lambda: ETC / RC_NAME,
     lambda: USERS / getpass.getuser() / RC_NAME,
     lambda: APPDATADIR / RC_NAME,


### PR DESCRIPTION
funktionen `lambda: HOME / "." + RC_NAME` giver nedenstående fejl
når en `.fire.ini` bruges på Windows:

```
  File "c:\dev\fire\fire\cli\__init__.py", line 10, in <module>
    firedb = FireDb()
  File "c:\dev\fire\fire\api\firedb\base.py", line 70, in __init__
    self.config = get_configuration()
  File "c:\dev\fire\fire\api\configuration.py", line 60, in get_configuration
    parser.read(get_config_path())
  File "c:\dev\fire\fire\api\configuration.py", line 49, in get_config_path
    fname = get_fname()
  File "c:\dev\fire\fire\api\configuration.py", line 16, in <lambda>
    lambda: HOME / "." + RC_NAME,
TypeError: unsupported operand type(s) for +: 'WindowsPath' and 'str'
```

Fikses ved at indsætte et par paranteser:

`lambda: HOME / ("." + RC_NAME)`