### PR TITLE
niv udtræk-revision: Tilføj buffer ved søgning i opmålingsdistrikt

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -82,7 +82,7 @@ def udtræk_revision(projektnavn: str, kriterier: Tuple[str], **kwargs) -> None:
                     FROM (
                         SELECT DISTINCT g.punktid FROM geometriobjekt g
                         JOIN herredsogn hs
-                        ON sdo_inside(g.geometri, hs.geometri) = 'TRUE'
+                        ON sdo_inside(g.geometri, SDO_GEOM.SDO_BUFFER(hs.geometri, 50, 0.1)) = 'TRUE'
                         WHERE
                             upper(hs.kode) IN ({distrikter})
                         AND


### PR DESCRIPTION
Det hænder at opmålingsdistrikterne ikke er digitaliseret korrekt og
enkelte punkter fejlagtigt ikke medtages i revisionsudtrækket. Det
forsøges forhindret ved at søge i et udvidet opmålingsdistrikt (
buffer på 50 m).

Closes #473