### PR TITLE
bugfix: undgå at tilknyt_landsnr() tildeler ikke-sekventielle løbenumre

### DIFF
--- a/fire/api/firedb/__init__.py
+++ b/fire/api/firedb/__init__.py
@@ -288,7 +288,7 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
                     SELECT
                         regexp_substr(tekst, '.*-.*-(.+)', 1, 1, '', 1) lbnr
                     FROM punktinfo
-                    WHERE infotypeid={landsnr.infotypeid} AND REGEXP_LIKE(tekst, '{distrikt}-.+$')
+                    WHERE infotypeid={landsnr.infotypeid} AND REGEXP_LIKE(tekst, '^{distrikt}-.+$')
                 )
                 ORDER BY lbnr ASC
                 """


### PR DESCRIPTION
Grundet manglende ^ i regex fremsøges løbenumre for distriktet 29-06
både blandt landsnumre der starter med 29-06 *OG* 129-06. Hvilket
resulterer i at løbenumre i 29-06 springes over hvis de er optagede i
129-06. Rettet i dette commit.