### PR TITLE
Check om værdi findes i enum.

### DIFF
--- a/fire/api/model/__init__.py
+++ b/fire/api/model/__init__.py
@@ -1,8 +1,12 @@
 """SQLAlchemy models for the application
 """
+import enum
+
 import sqlalchemy.ext.declarative
 from sqlalchemy import Column, Integer, DateTime, String, func
 from sqlalchemy.dialects.oracle import TIMESTAMP
+
+from fire.enumtools import enum_values
 
 
 class BetterBehavedEnum(sqlalchemy.types.TypeDecorator):
@@ -13,7 +17,7 @@ class BetterBehavedEnum(sqlalchemy.types.TypeDecorator):
     Boolean.FALSE oversættes til 'false' og ikke 'FALSE'.
     """
 
-    def __init__(self, enumtype, *args, **kwargs):
+    def __init__(self, enumtype: enum.Enum, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._enumtype = enumtype
 
@@ -24,6 +28,8 @@ class BetterBehavedEnum(sqlalchemy.types.TypeDecorator):
             return value
 
     def process_result_value(self, value, dialect):
+        if value not in enum_values(self._enumtype):
+            return
         return self._enumtype(value)
 
 

--- a/fire/enumtools.py
+++ b/fire/enumtools.py
@@ -29,7 +29,7 @@ def enum_members(enum_class: Enum, names: List[str]) -> List[Enum]:
     return [enum_class[name] for name in names]
 
 
-def default_enums(enum):
+def default_enums(enum: Enum):
     """Returnerer liste med standard-enum-medlemmer for en given enum."""
     return enum_members(enum, enum_names(enum))
 
@@ -44,3 +44,9 @@ def selected_or_default(selected: str, enum: Enum) -> List[Enum]:
     if selected is None:
         return default_enums(enum)
     return [enum[selected]]
+
+
+def enum_values(enum: Enum) -> set:
+    """Returnerer de unikke værdier for enumerations-medlemmers for en given enum."""
+    return {item.value for item in enum}
+

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
-import pytest
+from enum import Enum
 
+import pytest
 from sqlalchemy.orm.exc import NoResultFound
 
 import fire.cli
@@ -218,3 +219,17 @@ def ark_punktoversigt():
 @pytest.fixture
 def række_punktoversigt():
     return basisrække(arkdef.PUNKTOVERSIGT)
+
+
+@pytest.fixture
+def enumeration():
+    class Enumeration(Enum):
+        medlem1 = 1
+        alias1 = 1
+        medlem2 = 2
+        alias2 = 2
+        medlem3 = 'test'
+        alias3 = 'test'
+        medlem4 = 'bob'
+        alias4 = 'bob'
+    return Enumeration

--- a/test/test_enumtools.py
+++ b/test/test_enumtools.py
@@ -32,10 +32,6 @@ def test_default_enums(enumeration):
     assert result == expected, f'Expected {result!r} to be {expected!r}'
 
 
-# def test_selected_or_default(enumeration):
-#     pass
-
-
 def test_enum_values(enumeration):
     expected = {1, 2, 'test', 'bob'}
     result = enum_values(enumeration)

--- a/test/test_enumtools.py
+++ b/test/test_enumtools.py
@@ -1,0 +1,43 @@
+from fire.enumtools import (
+    enum_names,
+    enum_aliases,
+    enum_members,
+    default_enums,
+    selected_or_default,
+    enum_values,
+)
+
+
+def test_enum_names(enumeration):
+    expected = ['medlem1', 'medlem2', 'medlem3', 'medlem4']
+    result = enum_names(enumeration)
+    assert result == expected, f'Expected {result!r} to be {expected!r}'
+
+
+def test_enum_aliases(enumeration):
+    expected = ['alias1', 'alias2', 'alias3', 'alias4']
+    result = enum_aliases(enumeration)
+    assert result == expected, f'Expected {result!r} to be {expected!r}'
+
+
+def test_enum_members(enumeration):
+    expected = [enumeration.medlem1, enumeration.medlem3]
+    result = enum_members(enumeration, ['medlem1', 'medlem3'])
+    assert result == expected, f'Expected {result!r} to be {expected!r}'
+
+
+def test_default_enums(enumeration):
+    expected = [enumeration.medlem1, enumeration.medlem2, enumeration.medlem3, enumeration.medlem4]
+    result = default_enums(enumeration)
+    assert result == expected, f'Expected {result!r} to be {expected!r}'
+
+
+# def test_selected_or_default(enumeration):
+#     pass
+
+
+def test_enum_values(enumeration):
+    expected = {1, 2, 'test', 'bob'}
+    result = enum_values(enumeration)
+    assert not (expected - result), f'Expected {result!r} to be {expected!r}'
+    assert not (result - expected), f'Expected {result!r} to be {expected!r}'


### PR DESCRIPTION
Sandsynligvis forårsaget af opdateringen af SQLAlchemy, havde BetterBehavedEnum nu brug for en validering af inputværdien, den skaber en enum-værdi ud fra, hvor den ikke var nødvendig før.

Valideringen foregår ved at se, om den ønskede værdi kan repræsenteres af den pågældende enum-klasse (nedarvet fra betterBehavedEnum). Kan den ikke dette, returnerer metoden, hvilket vil sige, den sender værdien `None` tilbage til den kaldende funktionalitet.