### PR TITLE
Tilføjelse af matematikmodul

### DIFF
--- a/fire/matematik.py
+++ b/fire/matematik.py
@@ -1,0 +1,104 @@
+from typing import Tuple
+import functools
+
+import numpy as np
+
+
+@functools.cache
+def Rneu_xyz(φ: float, λ: float) -> np.array:
+    """
+    Rotationsmatrix fra topocentriske (NEU) til geocentriske (XYZ) koordinater.
+
+    Input:
+
+        φ: Breddegrad
+        λ: Længdegrad
+
+    Brug rotationsmatrixen til fx at konvertere en kovariansmatrix fra NEU- til XYZ-rum:
+
+        cov_xyz = np.array(
+            [
+                [xx, xy, xz],
+                [xy, yy, yz],
+                [xz, yz, zz],
+            ]
+        )
+
+        R = Rxyz_neu(lat, lon)
+        cov_xyz = R @ cov_neu @ R.T
+
+    Transponer rotationsmatrixen for at gå den anden vej (XYZ->NEU):
+
+        cov_neu = R.T @ cov_xyz @ R
+
+    For reference, se
+
+        T. Soler & M. Chin, 1985, On Transformation of Covariance Matrices Between
+        Local Cartesian Coordinate Systems and Communitative Diagrams
+
+    Jf. denne artikel skal der ikke tages særligt højde for tilfældet hvor koordinaterne
+    er relateret til ellipsoide frem for en kugle så længe den ellipsoidiske breddegrad
+    benyttes når koordinaterne er baseret på en ellipsoide.
+    """
+    sin = lambda x: np.sin(np.deg2rad(x))
+    cos = lambda x: np.cos(np.deg2rad(x))
+    # Bed Black om at holde fingrene væk - her ved vi bedre
+    # fmt: off
+    return np.array([
+        [-sin(φ)*cos(λ), -sin(λ), cos(φ)*cos(λ)],
+        [-sin(φ)*sin(λ),  cos(λ), cos(φ)*sin(λ)],
+        [        cos(φ),       0,        sin(φ)],
+    ])
+    # fmt: on
+
+
+def xyz2neu(
+    x: float, y: float, z: float, φ: float, λ: float
+) -> Tuple[float, float, float]:
+    """
+    Konverter koordinatdifferenser fra geocentrisk (XYZ) til topocentrisk (NEU) rum
+
+    Input:
+
+        x: x-komponent af geocentrisk koordinat
+        y: y-komponent af geocentrisk koordinat
+        z: z-komponent af geocentrisk koordinat
+        φ: Breddegrad
+        λ: Længdegrad
+
+    Output:
+
+        n: n-komponent af topocentrisk koordinat
+        e: e-komponent af topocentrisk koordinat
+        u: u-komponent af topocentrisk koordinat
+    """
+    R = Rneu_xyz(φ, λ).T
+    xyz = np.array([x, y, z])
+
+    return tuple(R @ xyz)
+
+
+def neu2xyz(
+    n: float, e: float, u: float, φ: float, λ: float
+) -> Tuple[float, float, float]:
+    """
+    Konverter koordinatdifferenser fra topocentrisk (NEU) til geocentrisk (XYZ) rum
+
+    Input:
+
+        n: n-komponent af topocentrisk koordinat
+        e: e-komponent af topocentrisk koordinat
+        u: u-komponent af topocentrisk koordinat
+        φ: Breddegrad
+        λ: Længdegrad
+
+    Output:
+
+        x: x-komponent af geocentrisk koordinat
+        y: y-komponent af geocentrisk koordinat
+        z: z-komponent af geocentrisk koordinat
+    """
+    R = Rneu_xyz(φ, λ)
+    neu = np.array([n, e, u])
+
+    return tuple(R @ neu)

--- a/test/test_matematik.py
+++ b/test/test_matematik.py
@@ -1,0 +1,58 @@
+from math import isclose
+
+import numpy as np
+
+from fire.matematik import (
+    neu2xyz,
+    xyz2neu,
+    Rneu_xyz,
+)
+
+W = 0.001 ** 2
+XX = 0.9145031116e-01
+XY = 0.1754111808e-01
+YY = 0.1860172410e-01
+XZ = 0.9706757931e-01
+YZ = 0.2230707662e-01
+ZZ = 0.1740501496e00
+
+COV_XYZ = (
+    np.array(
+        [
+            [XX, XY, XZ],
+            [XY, YY, YZ],
+            [XZ, YZ, ZZ],
+        ]
+    )
+    * W
+)
+
+
+def test_neu2xyz_og_xyz2neu():
+    """Test at neu2xyz og xyz2neu er hinandens inverse."""
+    n = 0.01
+    e = 0.025
+    u = 0.003
+
+    lat = 55.2
+    lon = 12.2
+
+    x, y, z = neu2xyz(n, e, u, lat, lon)
+    N, E, U = xyz2neu(x, y, z, lat, lon)
+
+    # undgå fejl pga floating point afrunding
+    assert isclose(n, N)
+    assert isclose(e, E)
+    assert isclose(u, U)
+
+
+def test_Rneu_xyz():
+    """
+    Test at rotationsmatrixen kan levere en fejlfri frem- og tilbage rotation.
+    """
+
+    R = Rneu_xyz(55.2, 12.2)
+    cov_neu = R.T @ COV_XYZ @ R
+    cov_xyz_return = R @ cov_neu @ R.T
+
+    assert np.allclose(COV_XYZ, cov_xyz_return)


### PR DESCRIPTION
Indeholder indtil videre funktioner til konvertering mellem geocentriske og topocentriske koordinatforskelle.

Som test (udover de formelle til test-suiten) har jeg lavet nogle forskellige forsøg med data fra ADDNEQ2. Nedenstående script beregner for BUDP rotationsmatrix (NEU->XYZ), NEU covariansmatrix (roteret XYZ covarians), spredninger fra de to covariansmatricer samt en ny XYZ-covariansmatrix baseret på NEU-spredninger fra ADDNEQ-filen. Se output helt i bunden.

Jeg er i tvivl om det hele stemmer. Den XYZ-covariansmatrix jeg beregner ud fra de empiriske NEU-spredninger er en størrelsesorden eller to større end hvad der findes i COV-filen. Om det skyldes fejl fra min side eller om det simpelthen bare er varianserne der bliver større når de er bestemt empirisk kontra når de beregnes (??) kan jeg ikke helt lure?

```python
import numpy as np

from fire.matematik import Rneu_xyz, neu2xyz, xyz2neu

# Covariansmatrix for BUDP fra COV fil
w = 0.001**2
xx = 0.9145031116e-01 * w
xy = 0.1754111808e-01 * w
yy = 0.1860172410e-01 * w
xz = 0.9706757931e-01 * w
yz = 0.2230707662e-01 * w
zz = 0.1740501496e00  * w

cov_xyz = np.array(
    [
        [xx, xy, xz],
        [xy, yy, yz],
        [xz, yz, zz],
    ]
)

# Empirisk NEU spredning for BUDP fra ADDNEQ fil
w = 0.001 # mm -> m
N = 0.28 * w
E = 0.92 * w
U = 4.01 * w

# covariansmatrix i NEU
R = Rneu_xyz(55.7390166848493, 12.5000197699936) # koordinat for BUDP
cov_neu = R.T @ cov_xyz @ R

# spredninger i neu
sigma_n, sigma_e, sigma_u = np.sqrt(cov_neu.diagonal())

# spredning i xyz, omregnet fra varianser i XYZ-covariansmatrix
sigma_x = np.sqrt(xx)
sigma_y = np.sqrt(yy)
sigma_z = np.sqrt(zz)

# NEU-spredninger konverteret til XYZ-covarians matrix
COV_XYZ = R @ np.diag([N**2, E**2, U**2]) @ R.T

print("Rotationsmatrix R, NEU->XYZ:")
print(R)
print("")

print("XYZ Covarians fra COV-fil:")
print(cov_xyz)
print("")

print("NEU covarians, beregnet ved rotation med R:")
print(cov_neu)
print("")

print("XYZ Spredning beregnet fra XYZ covariansmatrix:")
print(sigma_x, sigma_y, sigma_z)
print("")

print("NEU Spredning beregnet fra NEU covariansmatrix")
print(sigma_n, sigma_e, sigma_u)
print("")

print("Empiriske NEU-spredninger fra ADDNEQ fil")
print(N, E, U)
print("")

print("Empirisk XYZ kovariansmatrix omregnet fra empirisk NEU-spredning")
print(COV_XYZ)
print("\n\n\n\n\n")

```
Output
```
Rotationsmatrix R, NEU->XYZ:
[[-0.80689087 -0.21643995  0.54961885]
 [-0.17888369  0.97629593  0.12184776]
 [ 0.56296337  0.          0.82648185]]

XYZ Covarians fra COV-fil:
[[9.14503112e-08 1.75411181e-08 9.70675793e-08]
 [1.75411181e-08 1.86017241e-08 2.23070766e-08]
 [9.70675793e-08 2.23070766e-08 1.74050150e-07]]

NEU covarians, beregnet ved rotation med R:
[[2.76823771e-08 1.63320988e-11 1.04514417e-10]
 [1.63320988e-11 1.46011996e-08 9.19332599e-10]
 [1.04514417e-10 9.19332599e-10 2.41818608e-07]]

XYZ Spredning beregnet fra XYZ covariansmatrix:
0.00030240752497251124 0.0001363881376806649 0.0004171931801935406

NEU Spredning beregnet fra NEU covariansmatrix
0.00016638021848010756 0.0001208354235588087 0.0004917505548261994

Empiriske NEU-spredninger fra ADDNEQ fil
0.00028000000000000003 0.00092 0.00401

Empirisk XYZ kovariansmatrix omregnet fra empirisk NEU-spredning
[[4.94818552e-06 9.09345442e-07 7.26877225e-06]
 [9.09345442e-07 1.04799736e-06 1.61145064e-06]
 [7.26877225e-06 1.61145064e-06 1.10087171e-05]]
```