### PR TITLE
niv udtræk-revision: Tillad ident "genveje"

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import text
 
+from fire.ident import klargør_identer_til_søgning
 from fire.api.model import Punkt
 from fire.api.model.geometry import (
     normaliser_lokationskoordinat,
@@ -83,6 +84,7 @@ def udtræk_revision(
             opmålingsdistrikter.append(kriterie)
         else:
             løse_punkter.append(kriterie)
+    løse_punkter = klargør_identer_til_søgning(løse_punkter)
 
     if opmålingsdistrikter:
         distrikter = ",".join([f"'{d.upper()}'" for d in opmålingsdistrikter])


### PR DESCRIPTION
Gør det muligt at udtrække punkter med opslag der løseligt matcher
de fulde identer, fx ved udeladelse af foranstillede 0'er i et
landsnummers løbenummer eller brug små bogstaver frem for store.

Eksempel:

```
    $ fire niv udtræk-revision flaf k-63-9451 102-08-9067
    Punkt: 102-08-09067
    Punkt: K-63-09451
    Filen 'flaf-revision.xlsx' findes ikke.
    Skriver: {'Revision'}
    Til filen 'flaf-revision.xlsx'
    Færdig!
```

Closes #567