### PR TITLE
pytest: Fejl når advarsler udstedes

### DIFF
--- a/fire/api/model/columntypes.py
+++ b/fire/api/model/columntypes.py
@@ -10,6 +10,8 @@ class Geometry(UserDefinedType):
 
     name = "GEOMETRY"
 
+    cache_ok = True
+
     def __init__(self, dimension=None, srid=-1):
         self.dimension = dimension
         self.srid = srid
@@ -55,10 +57,16 @@ class Geometry(UserDefinedType):
 class Point(Geometry):
     name = "POINT"
 
+    cache_ok = True
+
 
 class Curve(Geometry):
     name = "CURVE"
 
+    cache_ok = True
+
 
 class LineString(Curve):
     name = "LINESTRING"
+
+    cache_ok = True

--- a/fire/api/model/geometry.py
+++ b/fire/api/model/geometry.py
@@ -18,6 +18,8 @@ __all__ = ["Geometry", "Point", "Bbox"]
 class Geometry(expression.Function):
     """Repræsenterer en geometri værdi."""
 
+    inherit_cache = True
+
     def __init__(self, geometry, srid=4326):
         if isinstance(geometry, str):
             self._geom = from_wkt(geometry)
@@ -54,6 +56,9 @@ class Geometry(expression.Function):
 
 
 class Point(Geometry):
+
+    inherit_cache = True
+
     def __init__(self, p, srid=4326):
         if isinstance(p, (list, tuple)):
             geom = dict(type="Point", coordinates=[p[0], p[1]])

--- a/test/gama/test_gama_read.py
+++ b/test/gama/test_gama_read.py
@@ -6,7 +6,7 @@ from fire.api.gama import GamaReader
 
 
 def test_read(firedb: FireDb, sag: Sag):
-    input_stream = open(Path(__file__).resolve().parent / "input/all_points.xml", "r")
-    reader = GamaReader(firedb, input_stream)
-
-    reader.read(sag.id)
+    filename = Path(__file__).resolve().parent / "input/all_points.xml"
+    with open(filename, "r") as input_stream:
+        reader = GamaReader(firedb, input_stream)
+        reader.read(sag.id)

--- a/test/gama/test_gama_write.py
+++ b/test/gama/test_gama_write.py
@@ -10,75 +10,71 @@ from fire.api.gama import GamaWriter
 
 def test_all_points(firedb: FireDb, tmp_path: Path):
     outfile = tmp_path / "all_points.xml"
-    output = open(outfile, "w")
-    writer = GamaWriter(firedb, output)
+    with open(outfile, "w") as output:
+        writer = GamaWriter(firedb, output)
 
-    writer.take_all_points()
-    writer.set_fixed_point_ids(["K-63-09946"])
+        writer.take_all_points()
+        writer.set_fixed_point_ids(["K-63-09946"])
 
-    parameters = configparser.ConfigParser()
-    parameters.read("fire-gama.ini")
-    writer.write(True, False, "test_all_points", parameters)
-    output.close
+        parameters = configparser.ConfigParser()
+        parameters.read("fire-gama.ini")
+        writer.write(True, False, "test_all_points", parameters)
 
 
 def test_in_polygon(firedb: FireDb, tmp_path: Path):
     outfile = tmp_path / "in_polygon.xml"
-    output = open(outfile, "w")
-    writer = GamaWriter(firedb, output)
+    with open(outfile, "w") as output:
+        writer = GamaWriter(firedb, output)
 
-    geometry = Geometry(
-        (
-            "POLYGON ((10.209 56.155, "
-            "10.209 56.158, "
-            "10.215 56.158, "
-            "10.215 56.155, "
-            "10.209 56.155))"
+        geometry = Geometry(
+            (
+                "POLYGON ((10.209 56.155, "
+                "10.209 56.158, "
+                "10.215 56.158, "
+                "10.215 56.155, "
+                "10.209 56.155))"
+            )
         )
-    )
-    observations = firedb.hent_observationer_naer_geometri(geometry, 5000)
-    writer.take_observations(observations)
+        observations = firedb.hent_observationer_naer_geometri(geometry, 5000)
+        writer.take_observations(observations)
 
-    writer.set_fixed_point_ids(["K-63-09946"])
+        writer.set_fixed_point_ids(["K-63-09946"])
 
-    parameters = configparser.ConfigParser()
-    parameters.read("fire-gama.ini")
-    writer.write(True, False, "test_in_polygon", parameters)
-    output.close
+        parameters = configparser.ConfigParser()
+        parameters.read("fire-gama.ini")
+        writer.write(True, False, "test_in_polygon", parameters)
     os.remove(outfile)
 
 
 def test_naer_geometry_time_interval(firedb: FireDb, tmp_path: Path):
     outfile = tmp_path / "near_geometry_time_interval.xml"
-    output = open(outfile, "w")
-    writer = GamaWriter(firedb, output)
+    with open(outfile, "w") as output:
+        writer = GamaWriter(firedb, output)
 
-    g = Geometry("POINT (10.200000 56.100000)")
-    observations = firedb.hent_observationer_naer_geometri(
-        g, 10000, datetime.datetime(2015, 10, 8), datetime.datetime(2018, 10, 9)
-    )
+        g = Geometry("POINT (10.200000 56.100000)")
+        observations = firedb.hent_observationer_naer_geometri(
+            g, 10000, datetime.datetime(2015, 10, 8), datetime.datetime(2018, 10, 9)
+        )
 
-    writer.take_observations(observations)
+        writer.take_observations(observations)
 
-    parameters = configparser.ConfigParser()
-    parameters.read("fire-gama.ini")
-    writer.write(True, False, "test_near_geometry_time_interval", parameters)
-    output.close
+        parameters = configparser.ConfigParser()
+        parameters.read("fire-gama.ini")
+        writer.write(True, False, "test_near_geometry_time_interval", parameters)
     os.remove(outfile)
 
 
 def test_naer_geometry(firedb: FireDb, tmp_path: Path):
     outfile = tmp_path / "near_geometry.xml"
-    output = open(outfile, "w")
-    writer = GamaWriter(firedb, output)
+    with open(outfile, "w") as output:
+        writer = GamaWriter(firedb, output)
 
-    g = Geometry("POINT (10.200000 56.100000)")
-    observations = firedb.hent_observationer_naer_geometri(g, 10000)
+        g = Geometry("POINT (10.200000 56.100000)")
+        observations = firedb.hent_observationer_naer_geometri(g, 10000)
 
-    writer.take_observations(observations)
+        writer.take_observations(observations)
 
-    parameters = configparser.ConfigParser()
-    parameters.read("fire-gama.ini")
-    writer.write(True, False, "test_near_geometry", parameters)
-    output.close
+        parameters = configparser.ConfigParser()
+        parameters.read("fire-gama.ini")
+        writer.write(True, False, "test_near_geometry", parameters)
     os.remove(outfile)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+
+[pytest]
+filterwarnings =
+    error
+    ignore::DeprecationWarning:pytest_freezegun


### PR DESCRIPTION
Pytest konfigureret, via `tox.ini`, til at fejle når en `*Warning` udstedes i koden. Der udstedes en del advarsler af SQLAlchemy i forbindelse med forberedelse til v. 2.0. Dem har vi hidtil overset. Med denne ændring skulle det gerne være meget tydeligt når en ny advarsel dukker op (= testsuiten fejler).

Alle eksisterende advarsler er taget hånd om. Primært handler de om SQLAlchemy, men enkelte forbedringer er også lavet i tests af `fire.gama` og en `DeprecationWarning` fra `pytest_freezegun` ignoreres. Sidstnævnte forsøges håndteret opstrøms men projektet ser ud til at være halvdødt, hvorfor jeg har forsøgt mig med at tilføje en patch i conda-forge pakken.  Forhåbentligt bliver sidstnævnte accepteret.

Tagget som milestone 1.4, da det er relevant at nævne at diverse SQLAlchemy advarsler nu undgås. 