### PR TITLE
Bugfix: Brug foreløbige navne når landsnumre ikke oprettet

### DIFF
--- a/fire/cli/niv/_læs_observationer.py
+++ b/fire/cli/niv/_læs_observationer.py
@@ -40,12 +40,10 @@ def læs_observationer(projektnavn: str, **kwargs) -> None:
         projektnavn, "Nyetablerede punkter", arkdef.NYETABLEREDE_PUNKTER
     )
     try:
-        nyetablerede = nyetablerede.set_index("Landsnummer")
-    except:
+        nyetablerede = nyetablerede.set_index("Landsnummer", verify_integrity=True)
+    except ValueError:
         fire.cli.print("Der mangler landsnumre til nyetablerede punkter.")
-        fire.cli.print(
-            "Har du husket at lægge dem i databasen - og at kopiere fanebladet fra resultatfilen?"
-        )
+        fire.cli.print("Har du husket at lægge dem i databasen?")
         fire.cli.print("Fortsætter beregningen med brug af de foreløbige navne")
         nyetablerede = nyetablerede.set_index("Foreløbigt navn")
     nye_punkter = set(nyetablerede.index)


### PR DESCRIPTION
Når nye punkter endnu ikke er oprettet kan `fire niv læs-observationer`
ikke udtrække landsnumrene, hvorfor de foreløbige navne skal bruges.
Det forventes at `set_index()` smider en exception ved duplerede
værdier i en kolonne (eksempelvis to tommer celler), men den antagelser
holder ikke (længere?). Denne adfærd sikres ved tilføjelse af
`verify_integrity=True` til kaldet.

Herefter udstedes advarsel som forventet til brugeren:

```
Der mangler landsnumre til nyetablerede punkter.
Har du husket at lægge dem i databasen?
Fortsætter beregningen med brug af de foreløbige navne
Importerer observationer
```

Fixes #573 