### PR TITLE
Påkræv beskrivelse ved nyoprettelse af punkter

### DIFF
--- a/fire/cli/niv/_ilæg_nye_punkter.py
+++ b/fire/cli/niv/_ilæg_nye_punkter.py
@@ -232,14 +232,24 @@ def ilæg_nye_punkter(projektnavn: str, sagsbehandler: str, **kwargs) -> None:
         )
 
         # Tilføj punktbeskrivelsen som punktinformation, hvis anført
-        if not pd.isna(nyetablerede["Beskrivelse"][i]):
-            punktinfo.append(
-                PunktInformation(
-                    infotype=beskrivelse_pit,
-                    punkt=punkt,
-                    tekst=nyetablerede["Beskrivelse"][i],
-                )
+        beskrivelse = nyetablerede["Beskrivelse"][i]
+        if pd.isna(beskrivelse) or beskrivelse == "":
+            navn = nyetablerede["Foreløbigt navn"][i]
+            fire.cli.print(
+                f"FEJL: Beskrivelse for punkt '{navn}' ikke angivet!",
+                fg="white",
+                bg="red",
+                bold=True,
             )
+            fire.cli.firedb.session.rollback()
+            raise SystemExit
+        punktinfo.append(
+            PunktInformation(
+                infotype=beskrivelse_pit,
+                punkt=punkt,
+                tekst=beskrivelse,
+            )
+        )
 
         # Tilknyt regionskode til punktet
         punktinfo.append(opret_region_punktinfo(punkt))


### PR DESCRIPTION
`fire niv ilæg-nye-punkter` fejler hvis beskrivelsesfeltet ikke er
udfyldt. Hermed undgår vi at der udstilles punkter uden beskrivelse
på Valdemar.

Hvis på punktoprettelsestidspunktet ikke er muligt at skrive den fulde
beskrivelse må en kort, midlertidig, tekst skrives og uddybes på et
senere tidspunkt.

Closes #561 