### PR TITLE
Fjern Konfiguration

### DIFF
--- a/fire/api/firedb/__init__.py
+++ b/fire/api/firedb/__init__.py
@@ -212,18 +212,6 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
         self.session.add(koordinat)
         self.session.commit()
 
-    @property
-    def basedir_skitser(self):
-        """Returner absolut del af sti til skitser."""
-        konf = self._hent_konfiguration()
-        return konf.dir_skitser
-
-    @property
-    def basedir_materiale(self):
-        """Returner absolut del af sti til sagsmateriale."""
-        konf = self._hent_konfiguration()
-        return konf.dir_materiale
-
     def _generer_tilladte_løbenumre(
         self, fikspunktstype: FikspunktsType
     ) -> Iterator[str]:

--- a/fire/api/firedb/base.py
+++ b/fire/api/firedb/base.py
@@ -16,7 +16,6 @@ from sqlalchemy.orm import sessionmaker
 from fire.api.model import (
     RegisteringTidObjekt,
     FikspunktregisterObjekt,
-    Konfiguration,
     Sagsevent,
     EventType,
     Observation,
@@ -92,13 +91,6 @@ class FireDbBase:
             connect_args={"encoding": "UTF-8", "nencoding": "UTF-8"},
             echo=self.debug,
             execution_options=self._exe_opt,
-        )
-
-    def _hent_konfiguration(self):
-        return (
-            self.session.query(Konfiguration)
-            .filter(Konfiguration.objektid == 1)
-            .first()
         )
 
     def _luk_fikspunkregisterobjekt(

--- a/fire/api/model/__init__.py
+++ b/fire/api/model/__init__.py
@@ -126,21 +126,6 @@ class RegisteringTidObjekt(DeclarativeBase):
         return self._registreringtil
 
 
-class Konfiguration(DeclarativeBase):
-    """
-    Konfigurationstabel for FIRE.
-
-    Tabellen har det særpræg at der kun kan indlæses en række i den.
-    Den indeholder derfor altid den nye udgave af opsætningen. Tabellen
-    er skabt for at kunne holde styr på systemspecifikke detaljer, der
-    kan ændre sig over tid, fx basestier på et filsystem.
-    """
-
-    __tablename__ = "konfiguration"
-    objektid = Column(Integer, primary_key=True)
-    dir_skitser = Column(String, nullable=False)
-
-
 # Expose these types
 from .geometry import *
 from .punkttyper import *

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -137,14 +137,6 @@ CREATE TABLE tidsserie_koordinat (
   koordinatobjektid INTEGER NOT NULL
 );
 
-CREATE TABLE konfiguration (
-  objektid INTEGER GENERATED ALWAYS AS IDENTITY (
-    START WITH
-      1 INCREMENT BY 1 ORDER NOCACHE
-  ) PRIMARY KEY,
-  dir_skitser VARCHAR(200) NOT NULL
-);
-
 
 CREATE TABLE observation (
   objektid INTEGER GENERATED ALWAYS AS IDENTITY (
@@ -427,9 +419,6 @@ ADD
     substr(SRID, 1, instr(SRID, ':') -1) IN ('DK', 'EPSG', 'GL', 'TS', 'IGS')
   ) ENABLE VALIDATE;
 
-
--- Index sikrer at der kun kan indsættes een række i tabellen
-CREATE UNIQUE INDEX konfiguration_only_one_row_idx ON konfiguration ('1');
 
 -- Index der skal sikre at der til samme punkt ikke tilføjes en koordinat
 -- med samme SRIDID, hvis denne ikke er afregistreret

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -32,12 +32,6 @@
 
 -- SRID, punktinfotype osv
 -------------------------------------------------------------------------------
--- Grundlæggende FIRE konfiguration
-INSERT INTO konfiguration (
-    dir_skitser
-) VALUES (
-    'F:\GDB\FIRE\skitser'
-)
 
 -- SELECT
 --   infotypeid, infotype, anvendelse, beskrivelse FROM punktinfotype

--- a/test/test_firedb.py
+++ b/test/test_firedb.py
@@ -3,7 +3,3 @@ from fire.api import FireDb
 
 def test_has_session(firedb: FireDb):
     assert hasattr(firedb, "session")
-
-
-def test_konfiguration(firedb: FireDb):
-    assert firedb.basedir_skitser == r"F:\GDB\FIRE\skitser"


### PR DESCRIPTION
Med indførelse af grafik-tabellen, og tilhørende kode, er Konfigurations
-tabel og -klasse blevet overflødig og kan betragtes som et fejlslået
eksperiment.

Closes #545

**Bemærk**: Ikke relevant at inkludere i release-notes til brugere