### PR TITLE
Brug openpyxl engine til opdatering af regneark

### DIFF
--- a/fire/io/regneark/__init__.py
+++ b/fire/io/regneark/__init__.py
@@ -215,6 +215,8 @@ def skriv_data(uddata: BinaryIO, faner: Mapping[str, pd.DataFrame]):
 
     """
     ewkw = dict(encoding="utf-8", index=False)
-    with pd.ExcelWriter(uddata, mode="a", if_sheet_exists="replace") as writer:
+    with pd.ExcelWriter(
+        uddata, mode="a", if_sheet_exists="replace", engine="openpyxl"
+    ) as writer:
         for navn, ark in faner.items():
             ark.to_excel(writer, sheet_name=navn, **ewkw)


### PR DESCRIPTION
Det er tilsyneladende ikke muligt at åbne et regneark i appen-mode med
`xlsxwriter`, derfor bruges i stedet `openpyxl`.

Closes #585