### PR TITLE
niv ilæg-nye-punkter: undlad at omskrive tekst i afmærkningsfelt

### DIFF
--- a/fire/cli/niv/_ilæg_nye_punkter.py
+++ b/fire/cli/niv/_ilæg_nye_punkter.py
@@ -208,7 +208,6 @@ def ilæg_nye_punkter(projektnavn: str, sagsbehandler: str, **kwargs) -> None:
                 .rstrip(".")
                 .strip()
             )
-            nyetablerede.at[i, "Afmærkning"] = f"AFM:{afm_id} - {beskrivelse}"
 
         if afm_id == 4999:
             fire.cli.print(


### PR DESCRIPTION
Tidligere er variationer af fx "bolt" ved opdatering af regneark
blevet omskrevet til "AFM:2700 - Bolt". Det har to ulemper:

1. Det gør det svært at debugge fejl
2. Det træner brugerne til at tro det er måden afmærningstypen angives på

Relateret til #578 