### PR TITLE
info punkt: Sikr at punkinfos talværdi skrives hvis den er 0.0

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -125,7 +125,12 @@ def punktinforapport(punktinformationer: List[PunktInformation]) -> None:
         # efter mellemrum rykkes teksten ind på linje med resten af
         # attributteksten
         tekst = tekst.replace("\n", "\n" + " " * 30).replace("\r", "").rstrip(" \n")
-        tal = info.tal or ""
+
+        tal = info.tal
+        # info.tal *kan* være 0.0, derfor explicit tjek af Noneness
+        if info.tal is None:
+            tal = ""
+
         # marker slukkede punktinformationer med rød tekst og et minus tv for linjen
         if info.registreringtil:
             fire.cli.print(f" -{info.infotype.name:27} {tekst}{tal}", fg="red")


### PR DESCRIPTION
Tidligere lavedes et for simpelt tjek af om talværdien af et punktinfo
er sat eller ej. I tilfældet hvor talværdien er 0.0 vil `info.tal or ""`
resultere i den tomme streng da 0.0 evaluerer False. Tages hånd om ved
et mere eksplicit tjek af variables indhold