### PR TITLE
Undgå fejl ved revision af lokationskoordinatløse punkter

### DIFF
--- a/fire/cli/niv/_ilæg_revision.py
+++ b/fire/cli/niv/_ilæg_revision.py
@@ -117,7 +117,13 @@ def ilæg_revision(
     for row in lokation.to_dict("records"):
         punkt = fire.cli.firedb.hent_punkt(row["Punkt"])
         # gem her inden ny geometri tilknyttes punktet
-        (λ1, φ1) = punkt.geometri.koordinater
+        try:
+            (λ1, φ1) = punkt.geometri.koordinater
+        except AttributeError:
+            # hvis ikke punktet har en lokationskoordinat bruger vi (11, 56), da dette
+            # er koordinaten der skrives i revisionsregnearket ved udtræk når der
+            # mangler en lokationskoordinat.
+            (λ1, φ1) = (11.0, 56.0)
 
         go = læs_lokation(row["Ny værdi"])
         go.punkt = punkt


### PR DESCRIPTION
Ved revision af lokationskoordinater bruges den eksisterende koordinat
til en rudimentær kontrol af fejlindlæsning af nye koordinater. Når et
punkt mangler en lokationskoordinat fejler læsningen og programmet
afbrydes. Dette commit tager hånd om dette og bruger koordinaten (11.0,
56.0) som den eksisterende lokationskoordinat. Dette er analogt til hvad
der skrives i revisionsregnearket ved udtræk.