### PR TITLE
Tilføj --historik flag til fire info punkt

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -355,7 +355,7 @@ def punkt_fuld_rapport(
     "--historik",
     is_flag=True,
     default=False,
-    help="Udskriv også ikke-gældende elementer",
+    help="Udskriv også ikke-gældende (historiske) elementer",
 )
 @click.option(
     "-n",


### PR DESCRIPTION
Standardvisningen af information om et punkt ændres til kun at vise
aktuelt data. Tidligere versioner af punktinfo m.m. vises ved
tilføjelse af `-H` eller `--historik` i kald til `fire info punkt`.

Ændringen foretages da det efter lang tids brug er vurderet at de
historiske informationer støjer mere end de gavner i de fleste udtræk.

Closes #247 