### PR TITLE
Undgå punktrevision i andre regioner end DK

### DIFF
--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -57,6 +57,11 @@ def udtræk_revision(
         "ATTR:tabtgået",
         "ATTR:teknikpunkt",
         "ATTR:MV_punkt",
+        "REGION:EE",
+        "REGION:FO",
+        "REGION:GL",
+        "REGION:SE",
+        "REGION:SJ",
     ]
 
     # Disse attributter indgår ikke i punktrevisionen


### PR DESCRIPTION
Ansporet af revisionsudtræk i Sønderjylland ændres funktionaliteten
sådan at punkter markeret med REGION:EE, REGION:FO, REGION:GL,
REGION:SE og REGION:SJ ikke trækkes ud i forbindelse med punktrevision.

Konkret betyder det ca. en faktor 10 færre udtrukne punkter i
sønderjyske opmålingsdistrikter, fx 1748 vs 174 i K-84.