### PR TITLE
Anvend kanoniske identer for nyetablerede punkter i læs_observationer

### DIFF
--- a/docs/workshop/htscase.rst
+++ b/docs/workshop/htscase.rst
@@ -278,15 +278,6 @@ Indlæs nu observationerne fra den første mgl-fil. Under fanen **Filoversigt** 
 
 .. image:: figures/filoversigt_2000.PNG
 
-.. warning::
-
-    Pga. en mindre, ikke-fatal fejl/uhensigtsmæssighed, som netop er opdaget i FIRE, så
-    skal du inden du fortsætter slette indholdet af fanen **Nyetablerede punkter**
-    med undtagelse af overskrifterne.
-
-    Fejlen gør så Punktoversigten bliver oprettet med dubletter af de nyoprettede punkter,
-    hvis kanoniske ident er forskellig fra landsnummeret, dvs. vores nye GI-punkt.
-
 Luk arket og indlæs observationerne med::
 
     fire niv læs-observationer HTS_DEMO --kotesystem Jessen


### PR DESCRIPTION
Fixer et problem, hvor punktoversigten blev opbygget med landsnumre for nyetablerede punkter og kanoniske identer for observerede punkter, hvilket førte til dubletter af punkter i punktoversigten i de tilfælde hvor et nyetableret punkts kanoniske ident ikke var landsnummeret (Fx. hvis man opretter et GI-punkt eller GNSS-punkt.)

Løsningen er at slå alle de nyetablerede punkter op i databasen for at hente kanoniske identer. Førhen var `læs_observationer` ellers uafhængig af databaseopslag, så det fører nok til at kommandoen bliver minimalt langsommere.