### PR TITLE
Slet kode som allerede er faktoriseret ud i "udfyld_udeladte_identer"

### DIFF
--- a/src/fire/cli/niv/_ilæg_revision.py
+++ b/src/fire/cli/niv/_ilæg_revision.py
@@ -516,16 +516,6 @@ def ilæg_revision(
         )
         raise SystemExit
 
-    # Udfyld udeladte identer
-    punkter = list(revision["Punkt"])
-    udfyldningsværdi = ""
-    for i in range(len(punkter)):
-        if punkter[i].strip() != "":
-            udfyldningsværdi = punkter[i].strip()
-            continue
-        punkter[i] = udfyldningsværdi
-    revision["Punkt"] = punkter
-
     # Find alle punkter, der skal nyoprettes
     nye_punkter = []
     oprettelse = revision.query("Attribut == 'OPRET'")


### PR DESCRIPTION
Endnu en gammel rettelse som ikke er kommet med endnu.

De tomme identer i revisionsarket blev udfyldt to gange. Det ledte ikke til fejl, men linjerne var overflødige.