### PR TITLE
Implementer søgefunktionalitet i fire ts gnss/hts

### DIFF
--- a/src/fire/api/firedb/hent.py
+++ b/src/fire/api/firedb/hent.py
@@ -209,9 +209,37 @@ class FireDbHent(FireDbBase):
         """
         return (
             self.session.query(Tidsserie)
-            .filter(Tidsserie.navn == navn, Tidsserie._registreringtil == None)  # NOQA
+            .filter(
+                Tidsserie.navn.ilike(navn),
+                Tidsserie._registreringtil == None,
+            )  # NOQA
             .one()
         )
+
+    def hent_tidsserier(
+            self,
+            navn: str,
+            tidsserieklasse: type[Tidsserie]=Tidsserie,
+        ) -> Tidsserie:
+        """
+        Hent tidsserier ud fra på søgekriterier.
+
+        Der søges på tidsserienavne som indeholder søgeteksten `navn` og der filtreres
+        yderligere på Tidsserie-type.
+        """
+
+        filtre = [
+            tidsserieklasse._registreringtil == None,
+            tidsserieklasse.navn.ilike(f"%{navn or ''}%"),
+        ]
+
+        tidsserier = (
+            self.session.query(tidsserieklasse)
+            .filter(*filtre)
+            .all()
+        )  # NOQA
+
+        return tidsserier
 
     def hent_geometri_objekt(self, punktid: str) -> GeometriObjekt:
         go = aliased(GeometriObjekt)

--- a/test/test_tidsserie.py
+++ b/test/test_tidsserie.py
@@ -3,6 +3,7 @@ from sqlalchemy.exc import NoResultFound
 
 import fire
 from fire.api.model import (
+    GNSSTidsserie,
     HøjdeTidsserie,
 )
 from fire.api.model.observationer import (
@@ -90,6 +91,20 @@ def test_hent_tidsserie_fra_navn(firedb):
 
     with pytest.raises(NoResultFound):
         firedb.hent_tidsserie("Findes ikke")
+
+
+def test_hent_tidsserier_fra_søgetekst(firedb):
+    tidsserier = firedb.hent_tidsserier("HTS_AARHUS", tidsserieklasse=HøjdeTidsserie)
+
+    assert len(tidsserier) == 3
+
+    tidsserier = firedb.hent_tidsserier("_5D_IG", tidsserieklasse=GNSSTidsserie)
+
+    assert len(tidsserier) == 2
+
+    tidsserier = firedb.hent_tidsserier("Findes ikke")
+
+    assert len(tidsserier) == 0
 
 
 def test_tidsserie_koordinater_observationer(firedb):


### PR DESCRIPTION
- Slettet hjælpefunktionen `_find_tidsserie` og indbygget en udvidet version af denne kaldet `hent_tidsserier` i api.firedb.hent-modulet

- Udbyg hjælpefunktionen `_udtræk_tidsserie` med filtrering på srid samt anvend `hent_tidsserier` i stedet for `_find_tidsserie`

- Tilføj parameter `-s/--srid` på fire ts gnss

Fixes #780 