### PR TITLE
Undgå OverflowError i `til_decimalår` for datoer før Unix-epoken

### DIFF
--- a/src/fire/api/model/tidsserier.py
+++ b/src/fire/api/model/tidsserier.py
@@ -29,24 +29,19 @@ __all__ = [
 ]
 
 
-def til_decimalår(date):
+def til_decimalår(date: dt):
     """
-    Stjålet fra StackOverflow og omdøbt:
+    Stjålet fra StackOverflow, og lettere omskrevet:
 
     https://stackoverflow.com/a/6451892
     """
-
-    def sinceEpoch(date):  # returns seconds since epoch
-        return time.mktime(date.timetuple())
-
-    s = sinceEpoch
 
     year = date.year
     startOfThisYear = dt(year=year, month=1, day=1)
     startOfNextYear = dt(year=year + 1, month=1, day=1)
 
-    yearElapsed = s(date) - s(startOfThisYear)
-    yearDuration = s(startOfNextYear) - s(startOfThisYear)
+    yearElapsed = (date - startOfThisYear).total_seconds()
+    yearDuration = (startOfNextYear - startOfThisYear).total_seconds()
     fraction = yearElapsed / yearDuration
 
     return date.year + fraction

--- a/test/api/tidsserier/test_tidsserie_attributter.py
+++ b/test/api/tidsserier/test_tidsserie_attributter.py
@@ -1,4 +1,7 @@
+from datetime import datetime as dt
 import pytest
+
+import numpy as np
 
 import fire
 from fire.cli import FireDb
@@ -7,6 +10,7 @@ from fire.api.model import (
     HøjdeTidsserie,
     GNSSTidsserie,
 )
+from fire.api.model.tidsserier import til_decimalår
 
 
 def test_tidsserie_attributter(firedb: FireDb):
@@ -32,3 +36,22 @@ def test_tidsserie_attributter(firedb: FireDb):
     for k, sz in zip(ts.kote, ts.sz):
         assert isinstance(k, float)
         assert isinstance(sz, float)
+
+
+def test_til_decimålår(firedb: FireDb):
+
+    assert til_decimalår(dt(3000, 1, 1, 0, 0)) == 3000
+    assert til_decimalår(dt(2025, 1, 1, 0, 0)) == 2025
+    assert til_decimalår(dt(1700, 1, 1, 0, 0)) == 1700
+
+    # Tjek at to ens datoer i forskellige år giver samme fraktion
+    fraktion_1 = til_decimalår(dt(987, 10, 11, 0, 0)) - 987
+    fraktion_2 = til_decimalår(dt(2345, 10, 11, 0, 0)) - 2345
+
+    assert np.isclose(fraktion_1, fraktion_2)
+
+    # Tjek at vi kan regne en tidsserie om til decimalår
+    ts = firedb.hent_tidsserie("RDIO_5D_IGb08")
+    assert len(ts.decimalår) == 10
+
+    return


### PR DESCRIPTION
For at få tidsforskellen mellem to datoer i sekunder, blev datoen først omsat til sekunder siden Unix-epoken, hvilket kunne give fejl hvis denne var negativ.

Nu beregnes tidsforskellen som et timedelta-objekt, som omsættes direkte til forskel i sekunder via `total_seconds`-metoden.

Fixes #759 