### PR TITLE
fix(cli): importer pandas Styler

### DIFF
--- a/src/fire/cli/niv/__init__.py
+++ b/src/fire/cli/niv/__init__.py
@@ -9,6 +9,7 @@ from typing import (
 
 import click
 import pandas as pd
+import pandas.io.formats.style
 from sqlalchemy.orm.exc import NoResultFound
 from openpyxl.worksheet.worksheet import Worksheet
 import packaging.version


### PR DESCRIPTION
førte til fejl ved nedenstående, da style.Styler ikke var importeret.
```
def påfør_df_style(df: pd.DataFrame) -> pd.io.formats.style.Styler:
    ...
```