### PR TITLE
Refaktorisering af tabeloutput

### DIFF
--- a/src/fire/cli/indlæs/bernese.py
+++ b/src/fire/cli/indlæs/bernese.py
@@ -4,9 +4,6 @@ from io import BytesIO
 from zipfile import ZipFile
 
 import click
-from rich.table import Table
-from rich.console import Console
-from rich import box
 from sqlalchemy.exc import NoResultFound, IntegrityError
 
 import fire.cli
@@ -28,6 +25,10 @@ from fire.cli.exceptions import (
     AfbrydFejl,
     advarsel,
     YndefuldeFejl,
+)
+from fire.cli.pretty_tables import (
+    generer_tabel,
+    print_tabel,
 )
 
 SRIDINDEX = {
@@ -168,15 +169,15 @@ def print_koordinat_tabel(koordinater: List[Koordinat]) -> None:
     """
     Skriv liste med nye koordinater til indsættelse i databasen.
     """
-    koordinattabel = Table("Station", "T", "X", "Y", "Z", box=box.SIMPLE)
 
-    for k in koordinater:
-        koordinattabel.add_row(
-            k.punkt.gnss_navn, str(k.t), str(k.x), str(k.y), str(k.z)
-        )
+    header = ["Station", "T", "X", "Y", "Z"]
+    rows = [
+        [k.punkt.gnss_navn, str(k.t), str(k.x), str(k.y), str(k.z)]
+        for k in koordinater
+    ]
 
-    console = Console()
-    console.print(koordinattabel)
+    koordinattabel = generer_tabel(header, rows)
+    print_tabel(koordinattabel)
 
 
 def komprimer(filer: List[click.File]) -> bytes:

--- a/src/fire/cli/info/_info.py
+++ b/src/fire/cli/info/_info.py
@@ -918,7 +918,6 @@ def _grupper_sagsevents(sagsevent_liste: list[Sagsevent]) -> dict[set]:
     "-r",
     "--rapport",
     type=str,
-    default=None,
     is_flag=False,
     flag_value="",
     help="Udskriv rapport over fremsøgte sager. Gives et navn på rapporten skrives også en geojson-fil som oversigt.",

--- a/src/fire/cli/info/_info.py
+++ b/src/fire/cli/info/_info.py
@@ -27,6 +27,8 @@ from fire.api.model import (
     PunktSamling,
     Koordinat,
     Observation,
+    GeometriskKoteforskel,
+    TrigonometriskKoteforskel,
     Boolean,
     Srid,
     Tidsserie,
@@ -38,43 +40,56 @@ from fire.cli.exceptions import (
     IntetAtGøre,
     YndefuldeFejl,
 )
+from fire.cli.pretty_tables import (
+    klargør_celle,
+    print_tabel,
+    generer_rapporttabel,
+)
+from rich.table import Table
 
 # Dato-format til kommandolinie-argument.
 DATE_FORMAT = "%d-%m-%Y"
 
 
-def observation_linje(obs: Observation) -> str:
+def observation_linje(
+    obs: GeometriskKoteforskel | TrigonometriskKoteforskel,
+) -> tuple[list[str], str]:
     if obs.observationstypeid > 2:
-        return ""
+        return [], None
 
     if obs.slettet:
-        return ""
+        return [], None
 
-    fra = obs.opstillingspunkt.ident
-    til = obs.sigtepunkt.ident
-    dH = obs.value1
-    L = obs.value2
-    N = int(obs.value3)
+    metode = "G" if obs.observationstypeid == 1 else "T"
     tid = obs.observationstidspunkt.strftime("%Y-%m-%d %H:%M")
-    grp = obs.gruppe
-    oid = obs.objektid
 
-    # Geometrisk nivellement
-    if obs.observationstypeid == 1:
-        præs = int(obs.value7)
-        eta_1 = obs.value4
-        fejlfaktor = obs.value5
-        centrering = obs.value6
-        return f"G {præs} {tid}   {dH:+09.6f}   {L:6.1f} {N:2}   {fra:12} {til:12}    {fejlfaktor:3.1f} {centrering:4.2f} {eta_1:+07.2f} {grp:6} {oid:6}"
+    # Kun GeometriskKoteForskel har disse to attributter.
+    # Hvis observationen er Trigonometrisk skrives 0 i stedet.
+    præs = getattr(obs, "præcisionsnivellement", 0)
+    eta_1 = getattr(obs, "eta_l", 0.0)
 
-    # Trigonometrisk nivellement
-    if obs.observationstypeid == 2:
-        fejlfaktor = obs.value4
-        centrering = obs.value5
-        return f"T 0 {tid}    {dH:+09.6f}  {L:6.1f} {N:2}   {fra:12} {til:12}    {fejlfaktor:3.1f} {centrering:4.2f}    0.00 {grp:6} {oid:6}"
+    row = [
+        "X" if obs.fejlmeldt else "",
+        f"{metode} {præs} {tid}",
+        f"{obs.koteforskel:+09.6f}",
+        f"{obs.nivlængde:6.1f}",
+        f"{obs.opstillinger:2}",
+        obs.opstillingspunkt.ident,
+        obs.sigtepunkt.ident,
+        f"{obs.spredning_afstand:3.1f}",
+        f"{obs.spredning_centrering:4.2f}",
+        f"{eta_1:+07.2f}",
+        f"{obs.gruppe:6}",
+        f"{obs.objektid:6}",
+    ]
+
+    # set row styles
+    style = "" if not obs.fejlmeldt else "red"
+
+    return row, style
 
 
-def koordinat_linje(koord: Koordinat) -> str:
+def koordinat_linje(koord: Koordinat) -> tuple[list[str], str]:
     """
     Konstruer koordinatoutput i overensstemmelse med koordinatens dimensionalitet,
     enhed og proveniens.
@@ -82,8 +97,8 @@ def koordinat_linje(koord: Koordinat) -> str:
     native_or_transformed = "t"
     if koord.transformeret == Boolean.FALSE:
         native_or_transformed = "n"
-
-    meta = f"{koord.t.strftime('%Y-%m-%d %H:%M')}  {(koord.srid.kortnavn or koord.srid.name):<15.15} {native_or_transformed} "
+    tid = koord.t.strftime("%Y-%m-%d %H:%M")
+    srid = f"{(koord.srid.kortnavn or koord.srid.name)}"
 
     # Se i proj.db: Er koordinatsystemet lineært eller vinkelbaseret?
     try:
@@ -96,62 +111,93 @@ def koordinat_linje(koord: Koordinat) -> str:
         if koord.srid.name == "GL:NAD83G":
             grader = True
 
-    dimensioner = 0
     if koord.x is not None and koord.y is not None:
-        dimensioner = 2
-
-    if koord.z is not None:
-        if dimensioner == 2:
-            dimensioner = 3
-        else:
-            dimensioner = 1
+        dimensioner = 3 if koord.z is not None else 2
+    else:
+        dimensioner = 1 if koord.z is not None else 0
 
     if dimensioner == 1:
-        linje = meta + f"{koord.z:.5f} ({koord.sz:.0f})"
-
+        xyz = f"{koord.z:.5f} ({koord.sz:.0f})"
     if dimensioner == 2:
         if grader:
-            linje = (
-                meta
-                + f"{koord.x:.10f}, {koord.y:.10f} ({koord.sx:.0f}, {koord.sy:.0f})"
-            )
+            xyz = f"{koord.x:.10f}, {koord.y:.10f} ({koord.sx:.0f}, {koord.sy:.0f})"
         else:
-            linje = (
-                meta + f"{koord.x:.4f}, {koord.y:.4f} ({koord.sx:.0f}, {koord.sy:.0f})"
-            )
+            xyz = f"{koord.x:.4f}, {koord.y:.4f} ({koord.sx:.0f}, {koord.sy:.0f})"
 
     if dimensioner == 3:
-        linje = meta + f"{koord.x:.10f}, {koord.y:.10f}, {koord.z:.5f}"
+        xyz = f"{koord.x:.10f}, {koord.y:.10f}, {koord.z:.5f}"
         if koord.sx is not None and koord.sy is not None and koord.sz is not None:
-            linje += f"  ({koord.sx:.0f}, {koord.sy:.0f}, {koord.sz:.0f})"
+            xyz += f" ({koord.sx:.0f}, {koord.sy:.0f}, {koord.sz:.0f})"
 
-    return linje
+    markør = "*"
+    style = "green"
+    if koord.registreringtil is not None:
+        markør = "X" if koord.fejlmeldt else "."
+        style = "red"
+
+    row = [markør, tid, srid, native_or_transformed, xyz]
+
+    return row, style
+
+
+def punktinfo_linje(punktinfo: PunktInformation) -> tuple[list[str], str]:
+    """Generér en tabelrække til punktinforapport."""
+    tekst = punktinfo.tekst or ""
+    # tal kan godt være 0, derfor tjekkes explicit for Noneness
+    tal = punktinfo.tal if punktinfo.tal is not None else ""
+
+    # marker slukkede punktinformationer med rød tekst og et minus tv for linjen
+    style, markør = "", ""
+    if punktinfo.registreringtil:
+        style, markør = "red", "-"
+    row = [f"{markør}{punktinfo.infotype.name}", f"{tekst}{tal}"]
+    return row, style
 
 
 def punktinforapport(
-    punktinformationer: List[PunktInformation], historik: bool
+    punkt: Punkt, historik: bool = False, detaljeret: bool = False
 ) -> None:
     """
-    Hjælpefunktion for 'punkt_fuld_rapport'.
+    Hjælpefunktion for 'punkt_fuld_rapport': Udskriv formateret punktinfo-tabel
     """
-    for info in punktinformationer:
-        tekst = info.tekst or ""
-        # efter mellemrum rykkes teksten ind på linje med resten af
-        # attributteksten
-        tekst = tekst.replace("\n", "\n" + " " * 30).replace("\r", "").rstrip(" \n")
+    tbl = generer_rapporttabel(
+        title=None,
+        show_header=False,
+        padding=(0, 2, 0, 2),
+    )
 
-        tal = info.tal
-        # info.tal *kan* være 0.0, derfor explicit tjek af Noneness
-        if info.tal is None:
-            tal = ""
+    # Tilføj Lokation og Oprettelsesdato
+    try:
+        for geometriobjekt in punkt.geometriobjekter:
+            # marker slukkede geometriobjekter med rød tekst og et minus tv for linjen
+            if geometriobjekt.registreringtil:
+                if not historik:
+                    continue
+                tbl.add_row("-Lokation", f"{geometriobjekt.geometri}", style="red")
+            else:
+                tbl.add_row("Lokation", f"{geometriobjekt.geometri}")
+    except Exception:
+        pass
 
-        # marker slukkede punktinformationer med rød tekst og et minus tv for linjen
-        if info.registreringtil:
-            if not historik:
-                continue
-            fire.cli.print(f" -{info.infotype.name:27} {tekst}{tal}", fg="red")
-        else:
-            fire.cli.print(f"  {info.infotype.name:27} {tekst}{tal}")
+    tbl.add_row("Oprettelsesdato", f"{punkt.registreringfra}")
+
+    # Tilføj de almindelige punktinformationer
+    for info in punkt.punktinformationer:
+        if info.registreringtil and not historik:
+            continue
+        row, style = punktinfo_linje(info)
+        tbl.add_row(*row, style=style)
+
+    # Tilføj detaljerede informationer
+    if detaljeret:
+        tbl.add_row("uuid", f"{punkt.id}")
+        tbl.add_row("objekt-id", f"{punkt.objektid}")
+        tbl.add_row("sagsid", f"{punkt.sagsevent.sagsid}")
+        tbl.add_row("sagsevent-fra", f"{punkt.sagseventfraid}")
+        if punkt.sagseventtilid is not None:
+            tbl.add_row(f"sagsevent-til", f"{punkt.sagseventtilid}")
+
+    print_tabel(tbl, align="left")
 
 
 def koordinatrapport(
@@ -173,17 +219,20 @@ def koordinatrapport(
 
     ts = True if "ts" in options.split(",") else False
     alle = True if "alle" in options.split(",") else False
+
+    tbl = generer_rapporttabel(title="--- Koordinater ---", show_header=False)
     for koord in koordinater:
         tskoord = koord.srid.name.startswith("TS:")
         if tskoord and not ts:
             continue
         if koord.registreringtil is not None:
-            if alle or (ts and tskoord) or historik:
-                markør = "X" if koord.fejlmeldt else "."
-                fire.cli.print(f"{markør} " + koordinat_linje(koord), fg="red")
-        else:
-            fire.cli.print("* " + koordinat_linje(koord), fg="green")
-    fire.cli.print("")
+            if not (alle or historik):
+                continue
+
+        row, style = koordinat_linje(koord)
+        tbl.add_row(*row, style=style)
+
+    print_tabel(tbl, align="left")
 
 
 def observationsrapport(
@@ -244,25 +293,32 @@ def observationsrapport(
     if n_vist == 0:
         return
 
-    fire.cli.print(
-        "    [Trig/Geom][Præs][T]     dH        L      N    Fra          Til             ne  d     eta    grp    id"
+    kolonnenavne = (
+        "",
+        "[Trig/Geom][Præs][T]",
+        "dH",
+        "L",
+        "N",
+        "Fra",
+        "Til",
+        "ne",
+        "d",
+        "eta",
+        "grp",
+        "id",
     )
-    fire.cli.print("  " + 110 * "-")
-    for obs in observationer:
-        linje = observation_linje(obs)
-        if linje != "" and linje is not None:
-            if obs.fejlmeldt:
-                fire.cli.print(" X  " + observation_linje(obs), fg="red")
-            else:
-                fire.cli.print("    " + observation_linje(obs))
 
-    fire.cli.print("  " + 110 * "-")
+    rows_styles = [observation_linje(obs) for obs in observationer]
+
+    tbl = generer_rapporttabel(
+        *kolonnenavne,
+        title="--- Observationer ---",
+        rows_styles=rows_styles,
+    )
 
     if not opt_detaljeret:
+        print_tabel(tbl, align="left")
         return
-
-    fire.cli.print(f"  Observationer ialt:  {n_obs_til + n_obs_fra}")
-    fire.cli.print(f"  Observationer vist:  {n_vist}")
 
     # Find ældste og yngste observation
     min_obs = datetime.datetime(9999, 12, 31, 0, 0, 0)
@@ -273,52 +329,46 @@ def observationsrapport(
         if obs.observationstidspunkt > max_obs:
             max_obs = obs.observationstidspunkt
 
-    fire.cli.print(f"  Ældste observation:  {min_obs}")
-    fire.cli.print(f"  Nyeste observation:  {max_obs}")
-    fire.cli.print("  " + 110 * "-")
+    tbl.caption = (
+        f"  Observationer ialt:  {n_obs_til + n_obs_fra}\n"
+        f"  Observationer vist:  {n_vist}\n"
+        f"  Ældste observation:  {min_obs}\n"
+        f"  Nyeste observation:  {max_obs}\n"
+    )
+    tbl.caption_style = ""
+    tbl.caption_justify = "left"
+    print_tabel(tbl, align="left")
 
 
 def punktsamlingsrapport(punktsamlinger: list[PunktSamling], id: str = None):
     """
     Hjælpefunktion for funktionerne punkt_fuld_rapport og punktsamling.
     """
-    kolonnebredder = (
-        34,
-        11,
-        13,
-        16,
-    )
-    kolonnenavne = ("Navn", "Jessenpunkt", "Antal punkter", "Antal tidsserier")
-    header = "  ".join([str(n).ljust(w) for n, w in zip(kolonnenavne, kolonnebredder)])
-    subheader = "  ".join(["-" * w for w in kolonnebredder])
 
-    fire.cli.print(header, bold=True)
-    fire.cli.print(subheader)
+    kolonnenavne = ("Navn", "Jessenpunkt", "Antal punkter", "Antal tidsserier")
+    tbl = generer_rapporttabel(
+        *kolonnenavne,
+        title="--- Punktsamlinger ---",
+    )
 
     punktsamlinger = [ps for ps in punktsamlinger if ps.registreringtil is None]
-
     # Sortér Punktsamlinger efter Jessennummer, dernæst efter Punktsamlingsnavn
     punktsamlinger.sort(key=lambda x: (x.jessenpunkt.jessennummer, x.navn))
 
     for ps in punktsamlinger:
-        farve = "white"
+        style = ""
         if ps.jessenpunkt.id == id:
-            farve = "green"
+            style = "green"
 
-        kolonner = [
+        row = [
             ps.navn,
             ps.jessenpunkt.jessennummer,
             len(ps.punkter),
             len(ps.tidsserier),
         ]
+        tbl.add_row(*[klargør_celle(c) for c in row], style=style)
 
-        linje = "  ".join(
-            [
-                textwrap.shorten(str(c), width=w, placeholder="...").ljust(w)
-                for c, w in zip(kolonner, kolonnebredder)
-            ]
-        )
-        fire.cli.print(linje, fg=farve)
+    print_tabel(tbl, align="left")
 
 
 def tidsserierapport(tidsserier: list[Tidsserie]):
@@ -326,14 +376,11 @@ def tidsserierapport(tidsserier: list[Tidsserie]):
     Hjælpefunktion for funktionerne punkt_fuld_rapport og punktsamling.
     """
 
-    kolonnebredder = [40, 17, 6, 18]
     kolonnenavne = ["Navn", "Antal datapunkter", "Type", "Referenceramme"]
-
-    header = "  ".join([str(n).ljust(w) for n, w in zip(kolonnenavne, kolonnebredder)])
-    subheader = "  ".join(["-" * w for w in kolonnebredder])
-
-    fire.cli.print(header, bold=True)
-    fire.cli.print(subheader)
+    tbl = generer_rapporttabel(
+        *kolonnenavne,
+        title="--- Tidsserier ---",
+    )
 
     def tidsserietype(tstype):
         if tstype == 1:
@@ -344,21 +391,12 @@ def tidsserierapport(tidsserier: list[Tidsserie]):
     for ts in tidsserier:
         if ts.registreringtil is not None:
             continue
-        navn_ombrudt = textwrap.wrap(str(ts.navn), kolonnebredder[0])
-        for navn_del in navn_ombrudt[:-1]:
-            fire.cli.print(navn_del)
 
-        kolonner = [
-            navn_ombrudt[-1],
-            len(ts),
-            tidsserietype(ts.tstype),
-            ts.referenceramme,
-        ]
+        row = [ts.navn, len(ts), tidsserietype(ts.tstype), ts.referenceramme]
 
-        linje = "  ".join([str(c).ljust(w) for c, w in zip(kolonner, kolonnebredder)])
-        fire.cli.print(linje)
+        tbl.add_row(*[klargør_celle(c) for c in row])
 
-    return
+    print_tabel(tbl, align="left")
 
 
 def punkt_fuld_rapport(
@@ -386,64 +424,39 @@ def punkt_fuld_rapport(
 
     # Geometri, fire-id, oprettelsesdato og PunktInformation håndteres
     # under et, da det giver et bedre indledende overblik
-    try:
-        for geometriobjekt in punkt.geometriobjekter:
-            # marker slukkede geometriobjekter med rød tekst og et minus tv for linjen
-            if geometriobjekt.registreringtil:
-                if not opt_historik:
-                    continue
-                fire.cli.print(
-                    f" -Lokation                    {geometriobjekt.geometri}", fg="red"
-                )
-            else:
-                fire.cli.print(
-                    f"  Lokation                    {geometriobjekt.geometri}"
-                )
-    except Exception:
-        pass
-
-    fire.cli.print(f"  Oprettelsesdato             {punkt.registreringfra}")
-
-    punktinforapport(punkt.punktinformationer, opt_historik)
-
-    if opt_detaljeret:
-        fire.cli.print(f"  uuid                        {punkt.id}")
-        fire.cli.print(f"  objekt-id                   {punkt.objektid}")
-        fire.cli.print(f"  sagsid                      {punkt.sagsevent.sagsid}")
-        fire.cli.print(f"  sagsevent-fra               {punkt.sagseventfraid}")
-        if punkt.sagseventtilid is not None:
-            fire.cli.print(f"  sagsevent-til               {punkt.sagseventtilid}")
+    punktinforapport(punkt, opt_historik, opt_detaljeret)
 
     if punkt.grafikker:
-        fire.cli.print("")
-        fire.cli.print("--- GRAFIK ---", bold=True)
+        tbl = generer_rapporttabel(
+            show_header=False,
+            title="--- Grafik ---",
+            padding=(0, 2, 0, 2),
+        )
         for grafik in punkt.grafikker:
             if grafik.registreringtil:
                 continue
-            print(f"{grafik.type.value.title():30}{grafik.filnavn}")
+            tbl.add_row(f"{grafik.type.value.title()}", f"{grafik.filnavn}")
+
+        fire.cli.print("")
+        print_tabel(tbl, align="left")
 
     # Koordinater og observationer klares af specialiserede hjælpefunktioner
     if "ingen" not in opt_koord.split(","):
         fire.cli.print("")
-        fire.cli.print("--- KOORDINATER ---", bold=True)
         koordinatrapport(punkt.koordinater, opt_koord, opt_historik)
 
     if opt_obs != "":
         fire.cli.print("")
-        fire.cli.print("--- OBSERVATIONER ---", bold=True)
         observationsrapport(
             punkt.observationer_til, punkt.observationer_fra, opt_obs, opt_detaljeret
         )
-        fire.cli.print("")
 
     if punkt.punktsamlinger:
         fire.cli.print("")
-        fire.cli.print("--- PUNKTSAMLINGER ---", bold=True)
         punktsamlingsrapport(punkt.punktsamlinger, punkt.id)
 
     if punkt.tidsserier:
         fire.cli.print("")
-        fire.cli.print("--- TIDSSERIER ---", bold=True)
         tidsserierapport(punkt.tidsserier)
 
 
@@ -1082,8 +1095,12 @@ def sagsevent(sagseventid: str, **kwargs) -> None:
     # oprettelse og nedlukning. De skal præsenteres på omtrent samme måde.
     # Nedenstående interne funktioner benyttes til dette.
     def _koordinatoversigt(koordinater: list[Koordinat]) -> None:
+        tbl = Table(box=None)
         for koordinat in koordinater:
-            fire.cli.print(f"{koordinat.punkt.ident:14} {koordinat_linje(koordinat)}")
+            row, style = koordinat_linje(koordinat)
+            # drop 1. kolonne som indeholder markøren
+            tbl.add_row(koordinat.punkt.ident, *row[1:])
+        print_tabel(tbl, align="left")
         fire.cli.print("\n")
 
     def _observationsoversigt(observationer: list[Observation]) -> None:
@@ -1122,8 +1139,18 @@ def sagsevent(sagseventid: str, **kwargs) -> None:
             punktinfo_oversigt[punktinfo.punkt].append(punktinfo)
 
         for punkt, punktinformationer in punktinfo_oversigt.items():
-            fire.cli.print(punkt.ident)
-            punktinforapport(punktinformationer, historik)
+            tbl = generer_rapporttabel(
+                title=punkt.ident,
+                show_header=False,
+            )
+            for info in punktinformationer:
+                if info.registreringtil and not historik:
+                    continue
+                # vi bruger ikke stilarten i denne sagseventrapport.
+                row, style = punktinfo_linje(info)
+                tbl.add_row(*row)
+
+            print_tabel(tbl, align="left")
             fire.cli.print("\n")
 
     def _grafikoversigt(grafikker: list[Grafik]) -> None:

--- a/src/fire/cli/info/_koordinater.py
+++ b/src/fire/cli/info/_koordinater.py
@@ -252,13 +252,11 @@ def klargør_transformationer(
         },
     }
     """
-    with YndefuldeFejl(NoResultFound, f"Source-srid '{src}' ikke fundet!"):
-        transformers = {
-            fire.cli.firedb.hent_srid(src := source): {
-                target: (trans := lav_transformer(source, target))
-            }
-            for source in sources
-        }
+    transformers = {}
+    for source in sources:
+        with YndefuldeFejl(NoResultFound, f"Source-srid '{source}' ikke fundet!"):
+            srid = fire.cli.firedb.hent_srid(source)
+        transformers[srid] = {target: (trans := lav_transformer(source, target))}
 
     try:
         target_srid = fire.cli.firedb.hent_srid(target)

--- a/src/fire/cli/opret.py
+++ b/src/fire/cli/opret.py
@@ -331,9 +331,7 @@ def punktopret(
     )
 
     fire.cli.print("\nOpretter punkt med følgende karakteristika:\n", bold=True)
-    fire.cli.print(f"  Lokation                    {punkt.geometri.geometri}")
-    fire.cli.print(f"  Oprettelsesdato             {punkt.registreringfra}")
-    punktinforapport(punktinformationer, historik=False)
+    punktinforapport(punkt, historik=False, detaljeret=False)
 
     with YndefuldeFejl(DatabaseError, "Punkt IKKE oprettet", med_årsag=True):
         fire.cli.firedb.indset_sagsevent(sagsevent_punktinfo_opret, commit=False)

--- a/src/fire/cli/pretty_tables.py
+++ b/src/fire/cli/pretty_tables.py
@@ -7,6 +7,7 @@ import pandas as pd
 from rich import box
 from rich.console import Console
 from rich.table import Table
+from rich.style import Style
 
 
 def klargør_celle(input):
@@ -44,7 +45,7 @@ def generer_tabel(
     format: str = "row",
 ) -> Table:
     """
-    Generer en rich.Table
+    Generer en simpelt formateret rich.Table
 
     Data antages at være givet som en liste med rækker i tabellen.
     Celleindeholdet konverteres først til `str`, og floats afrundes forinden til 4
@@ -77,6 +78,53 @@ def generer_tabel(
         )
 
     return tabel
+
+
+def generer_rapporttabel(
+    *kolonnenavne,
+    title,
+    title_justify: str = "left",
+    title_style: str | Style = "",
+    box: box.Box = box.SIMPLE,
+    show_header: bool = True,
+    header_style: str | Style = "",
+    padding: int | tuple[int] = (0, 1, 0, 0),
+    rows_styles: list[tuple[list, str | Style]] = [],
+    **kwargs,
+) -> Table:
+    """
+    Generér en rapport-tabel til brug i `info`-kommandogruppen
+
+    Fungerer som en wrapper om `rich.Table` der genererer standardopsætning af tabeller
+    til brug i `fire info`.
+
+    Rækker kan tilføjes med det samme via `rows_styles` som indholder en tuple for hver
+    tabelrække med tilhørende stilarter. Rækker kan også tilføjes bagefter via
+    `Table.add_row` metoden.
+
+    Sættes `show_header=False` vises kolonnenavne ikke.
+    **kwargs gives videre til `rich.Table`.
+    """
+    tbl = Table(
+        *kolonnenavne,
+        title=title,
+        title_justify=title_justify,
+        title_style=title_style,
+        box=box,
+        show_header=show_header,
+        header_style=header_style,
+        padding=padding,
+        **kwargs,
+    )
+
+    if rows_styles:
+        for row, style in rows_styles:
+            # Der kan være tomme rækker, som derfor springes over
+            if not row:
+                continue
+            tbl.add_row(*row, style=style)
+
+    return tbl
 
 
 def gem_til_excel(

--- a/src/fire/cli/pretty_tables.py
+++ b/src/fire/cli/pretty_tables.py
@@ -1,0 +1,124 @@
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+
+def klargør_celle(input):
+    if isinstance(input, datetime) or isinstance(input, int):
+        return str(input)
+    if isinstance(input, float):
+        return f"{input:.4f}"
+    if not input:
+        return ""
+    return str(input)
+
+
+def print_tabel(
+    tabel: Table,
+    console: Console = Console(),
+    align: str = "right",
+):
+    """
+    Print en rich.Table til konsollen
+
+    Alle kolonner højrejusteres for at gøre visuel inspektion af decimalpladser lettere.
+    Hertil antages at float-kolonner er afrundet til samme antal decimaler.
+    """
+
+    # Align kolonner til højre
+    for c in tabel.columns:
+        c.justify = align
+
+    console.print(tabel)
+
+
+def generer_tabel(
+    overskrifter: list[str],
+    data: list[list],
+    format: str = "row",
+) -> Table:
+    """
+    Generer en rich.Table
+
+    Data antages at være givet som en liste med rækker i tabellen.
+    Celleindeholdet konverteres først til `str`, og floats afrundes forinden til 4
+    decimaler.
+
+    Er data givet som lister med kolonner, kan dette angives med `format='col'`, hvorefter
+    data transponeres til række-format før videre behandling.
+
+    Uanset format, antages det at alle de indre lister har samme længde. Desuden skal antallet
+    af kolonner altid være lig antallet af overskrifter.
+    """
+    if not format in ("row", "col"):
+        raise ValueError("Format skal være 'row' eller 'col'")
+
+    # Erstat "[" med "\\[" så console.Print ikke opfatter det der står inde i [parentesen]
+    # som et "markup tag", se https://rich.readthedocs.io/en/latest/markup.html#
+    # Tiltænkt steder hvor kolonnen fx hedder "Kote [m]" eller "sz [mm]"
+    overskrifter = [re.sub(r"\[(?=.*\])", "\\[", o) for o in overskrifter]
+
+    tabel = Table(*overskrifter, box=box.SIMPLE, header_style="")
+
+    rækker = data
+    # Hvis liste af kolonner er givet, transponeres de til liste af rækker
+    if format == "col":
+        rækker = list(zip(*data))
+
+    for række in rækker:
+        tabel.add_row(
+            *[klargør_celle(celle) if celle is not None else "" for celle in række]
+        )
+
+    return tabel
+
+
+def gem_til_excel(
+    overskrifter: list[str],
+    data: list[list],
+    fil: Path,
+    format: str = "row",
+):
+    """
+    Gem data til excel
+
+    Er data givet som lister med kolonner, kan dette angives med `format='col'`, hvorefter
+    data transponeres til række-format før videre behandling.
+    """
+    if not format in ("row", "col"):
+        raise ValueError("Format skal være 'row' eller 'col'")
+
+    rækker = data
+    # Hvis liste af kolonner er givet, transponeres de til liste af rækker
+    if format == "col":
+        rækker = list(zip(*data))
+
+    df = pd.DataFrame.from_records(rækker, columns=overskrifter)
+    df.to_excel(fil, index=False)
+
+
+def gem_til_html(
+    tabel: Table,
+    fil: Path,
+):
+    """
+    Gem en pænt formatteret rich.Table som html
+    """
+    # Vi er kun interesseret i at gemme tabellen som html og ikke printe den.
+    # Men kan kun gemme til html, hvis det også printes til terminalen.
+    # Derfor benyttes dette trick der sørger for at der printes til devnull
+    # istedet for til stdout. Se
+    # https://github.com/Textualize/rich/discussions/1183#discussioncomment-649420
+    console = Console(record=True, file=open(os.devnull, "wt"))
+
+    # "Print" tabellen til devnull
+    print_tabel(tabel, console)
+
+    # ... og nu kan vi så gemme det som blev "printet"
+    console.save_html(fil)

--- a/src/fire/cli/ts/__init__.py
+++ b/src/fire/cli/ts/__init__.py
@@ -3,10 +3,6 @@ import re
 
 import click
 import pandas as pd
-from rich.table import Table
-from rich.console import Console
-from rich import box
-from sqlalchemy import func
 from sqlalchemy.exc import NoResultFound
 
 
@@ -19,6 +15,10 @@ from fire.api.model import (
     PunktSamling,
     Koordinat,
     Srid,
+)
+from fire.cli.exceptions import (
+    AfbrydFejl,
+    YndefuldeFejl,
 )
 
 
@@ -58,8 +58,6 @@ def _print_tidsserieoversigt(
 ) -> None:
     """
     Print en oversigt over en liste af tidsserier
-
-    raises:     SystemExit
     """
 
     def foretrukken_ident(ts: Tidsserie):
@@ -97,10 +95,9 @@ def _udtræk_tidsserie(
     `objekt` som ident.
     """
     if srid is not None:
-        try:
+        with YndefuldeFejl(NoResultFound, f"Srid '{srid}' ikke fundet i databasen."):
             srid = fire.cli.firedb.hent_srid(srid)
-        except NoResultFound:
-            raise SystemExit(f"Srid '{srid}' ikke fundet i databasen.")
+
         srid_filter = lambda ts: ts.srid == srid
     else:
         srid_filter = lambda ts: True
@@ -113,20 +110,18 @@ def _udtræk_tidsserie(
 
     # Hvis ingen tidsserier, prøver vi med objekt som ident
     if not tidsserier:
-        try:
+        with YndefuldeFejl(NoResultFound, "Punkt eller tidsserie ikke fundet"):
             punkt = fire.cli.firedb.hent_punkt(objekt)
-        except NoResultFound:
-            raise SystemExit("Punkt eller tidsserie ikke fundet")
-        else:
-            # Udtræk punktets tidsserier og filtrer på ts-type og srid
-            tidsserier = [
-                ts
-                for ts in punkt.tidsserier
-                if isinstance(ts, tidsserieklasse) and srid_filter(ts)
-            ]
+
+        # Udtræk punktets tidsserier og filtrer på ts-type og srid
+        tidsserier = [
+            ts
+            for ts in punkt.tidsserier
+            if isinstance(ts, tidsserieklasse) and srid_filter(ts)
+        ]
 
     if not tidsserier:
-        raise SystemExit("Fandt ingen tidsserier")
+        raise AfbrydFejl("Fandt ingen tidsserier")
 
     # Print oversigt over fundne tidsserier
     _print_tidsserieoversigt(tidsserier)
@@ -151,7 +146,7 @@ def _print_tidsserie(
     kolonner = []
     for p in parametre:
         if p not in parametre_alle.keys():
-            raise SystemExit(f"Ukendt tidsserieparameter '{p}'")
+            raise AfbrydFejl(f"Ukendt tidsserieparameter '{p}'")
 
         overskrifter.append(p)
         kolonner.append(tidsserie.__getattribute__(parametre_alle[p]))
@@ -178,8 +173,7 @@ def _print_tidsserier(
     """
     srid = tidsserier[0].srid
     if not all(ts.srid == srid for ts in tidsserier):
-        fire.cli.print("Fejl: Alle tidsserierne skal have samme Srid", fg="red")
-        raise SystemExit(1)
+        raise AfbrydFejl("Alle tidsserierne skal have samme Srid")
 
     overskrifter = ["Navn", "Srid"]
 

--- a/src/fire/cli/ts/__init__.py
+++ b/src/fire/cli/ts/__init__.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-import re
-
 import click
 import pandas as pd
 from sqlalchemy.exc import NoResultFound
@@ -20,7 +17,11 @@ from fire.cli.exceptions import (
     AfbrydFejl,
     YndefuldeFejl,
 )
-
+from fire.cli.pretty_tables import (
+    generer_tabel,
+    print_tabel,
+    gem_til_excel,
+)
 
 @click.group()
 def ts():
@@ -66,17 +67,17 @@ def _print_tidsserieoversigt(
         elif isinstance(ts, HøjdeTidsserie):
             return ts.punkt.ident
 
-    tabel = Table("Ident", "Tidsserienavn", "Referenceramme", box=box.SIMPLE)
-
     # Sorter tidsserier efter punkt
     tidsserier.sort(key=lambda ts: (foretrukken_ident(ts)))
 
-    for ts in tidsserier:
-        tabel.add_row(foretrukken_ident(ts), ts.navn, ts.referenceramme)
+    header = ["Ident", "Tidsserienavn", "Referenceramme"]
+    rows = [
+        [foretrukken_ident(ts), ts.navn, ts.referenceramme]
+        for ts in tidsserier
+    ]
 
-    console = Console()
-    console.print(tabel)
-
+    tabel = generer_tabel(header, rows)
+    print_tabel(tabel)
 
 def _udtræk_tidsserie(
     objekt: str,
@@ -151,15 +152,13 @@ def _print_tidsserie(
         overskrifter.append(p)
         kolonner.append(tidsserie.__getattribute__(parametre_alle[p]))
 
-    _print_tabel(
-        overskrifter,
-        kolonner,
-    )
+    tabel = generer_tabel(overskrifter, kolonner, format="col")
+    print_tabel(tabel)
 
     if not fil:
         return
 
-    _gem_tabel(overskrifter, kolonner, fil)
+    gem_til_excel(overskrifter, kolonner, fil, format="col")
 
 
 def _print_tidsserier(
@@ -195,51 +194,13 @@ def _print_tidsserier(
         for idx, p in enumerate(parametre, 2):
             kolonner[idx].extend(ts.__getattribute__(p))
 
-    _print_tabel(
-        overskrifter,
-        kolonner,
-    )
+    tabel = generer_tabel(overskrifter, kolonner, format="col")
+    print_tabel(tabel)
 
     if not fil:
         return
 
-    _gem_tabel(overskrifter, kolonner, fil)
-
-
-def _print_tabel(overskrifter: list, kolonner: list[list]):
-
-    # Erstat "[" med "\\[" så console.Print ikke opfatter det der står inde i [parentesen]
-    # som et "markup tag", se https://rich.readthedocs.io/en/latest/markup.html#
-    # Tiltænkt steder hvor kolonnen fx hedder "Kote [m]" eller "sz [mm]"
-    overskrifter = [re.sub(r"\[(?=.*\])", "\\[", o) for o in overskrifter]
-
-    tabel = Table(*overskrifter, box=box.SIMPLE, header_style="")
-    data = list(zip(*kolonner))
-
-    def klargør_celle(input):
-        if isinstance(input, datetime):
-            return str(input)
-        if isinstance(input, float):
-            return f"{input:.4f}"
-        if not input:
-            return ""
-        return str(input)
-
-    for række in data:
-        tabel.add_row(
-            *[klargør_celle(celle) if celle is not None else "" for celle in række]
-        )
-
-    console = Console()
-    console.print(tabel)
-
-
-def _gem_tabel(overskrifter: list, kolonner: list[list], fil: click.Path):
-    data = {
-        overskrift: kolonne for (overskrift, kolonne) in zip(overskrifter, kolonner)
-    }
-    df = pd.DataFrame(data)
-    df.to_excel(fil, index=False)
+    gem_til_excel(overskrifter, kolonner, fil, format="col")
 
 
 def skift_jessenpunkt(

--- a/src/fire/cli/ts/gnss.py
+++ b/src/fire/cli/ts/gnss.py
@@ -13,6 +13,9 @@ from fire.api.model import (
 from fire.api.model.tidsserier import (
     TidsserieEnsemble,
 )
+from fire.cli.pretty_tables import (
+    gem_til_excel,
+)
 from fire.cli.ts.plot_ts import (
     plot_tidsserie,
     plot_gnss_analyse,
@@ -746,17 +749,12 @@ def analyse_gnss(
 
     # Gem statistik
     if fil:
-        linjer = ""
+        rows = []
         for _, statistik in ts_statistik.items():
-            header = str(statistik).split("\n")[0]
-            linje = str(statistik).split("\n")[1]
+            rows.append(statistik.row())
 
-            linjer += f"{linje}\n"
-
-        outstr = f"{header}\n{linjer}"
-
-        with open(fil, "w") as f:
-            f.write(outstr)
+        header = statistik.header()
+        gem_til_excel(header, rows, fil)
 
     if not plot:
         return

--- a/src/fire/cli/ts/statistik_ts.py
+++ b/src/fire/cli/ts/statistik_ts.py
@@ -30,10 +30,11 @@ class Statistik:
     mex: float
     mey: float
 
-    def __str__(self):
-        header = ", ".join([str(field.name) for field in fields(self)])
-        linje = ", ".join([str(getattr(self, field.name)) for field in fields(self)])
-        return f"{header}\n{linje}"
+    def header(self):
+        return [str(field.name) for field in fields(self)]
+
+    def row(self):
+        return [str(getattr(self, field.name)) for field in fields(self)]
 
 
 @dataclass

--- a/test/cli/test_analyse_gnss.py
+++ b/test/cli/test_analyse_gnss.py
@@ -46,8 +46,8 @@ def test_cli_analyse_gnss_fejler(mocker, options):
     [
         (["--plot", "--referenceramme", "IGb08", "RDIO_5D_IGb08"], "."),
         (
-            ["--plot", "--fil", "test_statistik.csv", "RDIO_5D_IGb08"],
-            "test_statistik.csv",
+            ["--plot", "--fil", "test_statistik.xlsx", "RDIO_5D_IGb08"],
+            "test_statistik.xlsx",
         ),
         (["--plot", "--parameter", "e", "RDIO_5D_IGb08"], "."),
         (["--plot", "--grad", "2", "RDIO_5D_IGb08"], "."),

--- a/test/cli/test_pretty_tables.py
+++ b/test/cli/test_pretty_tables.py
@@ -1,0 +1,52 @@
+import pytest
+
+from fire.cli.pretty_tables import generer_tabel
+
+# Simpelt case
+hdrs_simpel = ["ones", "twos", "threes", "fours"]
+rows_simpel = [
+    [1, 2, 3, 4],
+    [1, 2, 3, 4],
+    [1, 2, 3, 4],
+]
+cols_simpel = [
+    [1, 1, 1],
+    [2, 2, 2],
+    [3, 3, 3],
+    [4, 4, 4],
+]
+
+# Mere kompleks case, med lange ord og celler
+hdrs_kompleks = ["et integer", "en float", "langt ord", "lang sætning"]
+rows_kompleks = [
+    [
+        j,
+        j + 1.23456,
+        f"et m{'e'*1000}get langt ord",
+        f"en {'meget, '*1000} lang sætning",
+    ]
+    for j in range(10)
+]
+# Konstruer samme data ud fra kolonnebaseret format
+cols_kompleks = (
+    [[j for j in range(10)]]
+    + [[j + 1.23456 for j in range(10)]]
+    + [[f"et m{'e'*1000}get langt ord" for j in range(10)]]
+    + [[f"en {'meget, '*1000} lang sætning" for j in range(10)]]
+)
+
+
+@pytest.mark.parametrize(
+    "headers, rows, cols",
+    [
+        (hdrs_simpel, rows_simpel, cols_simpel),
+        (hdrs_kompleks, rows_kompleks, cols_kompleks),
+    ],
+)
+def test_generer_tabel(headers, rows, cols):
+
+    tbl_from_rows = generer_tabel(headers, rows)
+    tbl_from_cols = generer_tabel(headers, cols, format="col")
+
+    assert tbl_from_rows.columns == tbl_from_cols.columns
+    assert tbl_from_rows.rows == tbl_from_cols.rows


### PR DESCRIPTION
Mener godt den her kan merges som den er. Måske skal det ikke hedde `pretty_tables` dog. Har ikke luget alt ud i cli laget så der er nok nogle steder, særlig `fire info` hvor man med fordel kunne bruge de her tabeller.

EDIT:

fca7986f03d7becce0d4c5806a8f06da86fcb2e4 og 
d9d1559ed663b2f31543324b140592998978609d 
behandler efterslæb fra forrige PR angående exceptions.

ee3a9a56c07b61c403bb0c7713aa25df7bb65ff8 frem til 
384bc6a152f596f4c472f9a08ec2e9e7be72e777
vedrører refaktorering af simpelt tabeloutput, som bruges i `fire ts`-kommandogruppen, samt et enkelt sted i `fire indlæs bernese`.

0469a3d434e87c6b88a2e118160df4bfc3ac2692 og frem
er en lidt større omgang vedr. tabeller som printes i `fire info`-kommandogruppen.
Har lavet en ny tabel-generator-funktion `generer_rapporttabel` som instansierer en `rich.Table` med standardopsætning
som bruges i hele `info`-gruppen.
Tabellernes udseende er stort set identisk, men tabel- og kolonnebredder er nu overladt til rich. 
Idet tabelopsætningen gerne skulle være mere overskuelig og vedligeholdbar nu, bør det være let at gå ind og rette i bredde-indstillinger for de enkelte tabeller/kolonner, skulle det vise sig at standardindstillingen er uhensigtsmæssig.

ce0fc3aab2f2875bc66642eb695ac87bcc4fc955 "patcher" en click-option som ikke opfører sig som beskrevet i click-dokumentationen.