### PR TITLE
Tilknyt landsnumre korrekt til SQLAlchemy Punkt-objekt

### DIFF
--- a/src/fire/api/firedb/__init__.py
+++ b/src/fire/api/firedb/__init__.py
@@ -97,7 +97,7 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
         """
         landsnr = self.hent_punktinformationtype("IDENT:landsnr")
 
-        uuider = []
+        uuid_punkter = {}
         punkttyper = {}
         for punkt, fikspunktstype in zip(punkter, fikspunktstyper):
             if not punkt.geometri:
@@ -106,13 +106,13 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
             # Ignorer punkter, der allerede har et landsnummer
             if landsnr in [pi.infotype for pi in punkt.punktinformationer]:
                 continue
-            uuider.append(f"{punkt.id}")
+            uuid_punkter[f"{punkt.id}"] = punkt
             punkttyper[punkt.id] = fikspunktstype
 
-        if not uuider:
+        if not uuid_punkter:
             return []
 
-        distrikter = self._opmålingsdistrikt_fra_punktid(uuider)
+        distrikter = self._opmålingsdistrikt_fra_punktid(uuid_punkter.keys())
         distrikt_punkter = cs.defaultdict(list)
         for distrikt, pktid in distrikter:
             distrikt_punkter[distrikt].append(pktid)
@@ -134,7 +134,7 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
 
         punktinfo = []
         for punktid, landsnummer in landsnumre.items():
-            pi = PunktInformation(punktid=punktid, infotype=landsnr, tekst=landsnummer)
+            pi = PunktInformation(punkt=uuid_punkter[punktid], infotype=landsnr, tekst=landsnummer)
             punktinfo.append(pi)
 
         return punktinfo


### PR DESCRIPTION
Den tiltænkte funktion er, at man oprettet et landsnr (PunktInformation), som via relationen til Punkt, "tilbage-propagerer" (back-propagates), sådan så både de to SQLAlchemy-objekter er knyttet til hinanden.

Førhen blev landsnumre oprettet med tilknytning til "punktid", og ikke selve Punkt-objektet, hvilket gør at relationen ikke "tilbage-propagerer" og at man først kan se relationen efter sessionen committes, og Punktet reloades.

Det er rettet nu, så Punktet fremgår med det nye landsnr i samme session som det er oprettet i.